### PR TITLE
Fase 2.3 — Topbar, stats, filtros, busca e atalhos em componentes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,9 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@testing-library/jest-dom": "^7.0.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -25,6 +28,13 @@
         "typescript": "^5",
         "vitest": "^4.1.10"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -282,6 +292,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2183,6 +2203,116 @@
         "tailwindcss": "4.3.3"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
+      "integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.4.tgz",
+      "integrity": "sha512-QCGwP6QrjypBLwyj5cuyfVamkaIEy/XGY+1VDehbtbQqOggYmTFpFOdWR5mPz14vX8vXLMVjDHlRNBcClyO9ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -2193,6 +2323,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3065,6 +3203,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3584,6 +3733,13 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -3749,6 +3905,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3771,6 +3938,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4997,6 +5172,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -5999,6 +6184,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6048,6 +6244,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -6565,6 +6771,44 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6635,6 +6879,20 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -7270,6 +7528,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^7.0.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,49 @@
 @import "tailwindcss";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --color-background: #0a0d12;
+  --color-foreground: #c6d0dd;
+  --font-mono: var(--font-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+html {
+  color-scheme: dark;
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  background: #0a0d12;
+  color: #c6d0dd;
+  font-family: var(--font-mono), ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+/* ---------- chip (padrão de ação/filtro) ---------- */
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  user-select: none;
+  color: #6b7787;
+  transition:
+    border-color 140ms,
+    background-color 140ms,
+    color 140ms,
+    transform 100ms;
+}
+.chip:hover {
+  color: #c6d0dd;
+  border-color: oklch(0.78 0.02 240 / 0.22);
+}
+.chip:active {
+  transform: scale(0.97);
+}
+.chip.border-current {
+  background: oklch(0.78 0.02 240 / 0.11);
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,87 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { FilterChips } from "@/components/client/FilterChips";
+import { Stats } from "@/components/client/Stats";
+import { Topbar } from "@/components/client/Topbar";
+import { useFilters } from "@/hooks/useFilters";
+import { useShortcuts } from "@/hooks/useShortcuts";
+import { blockedCount, countByStatus } from "@/lib/selectors";
+import { useBoard } from "@/lib/store";
+
 export default function Home() {
+  const projetos = useBoard((s) => s.projetos);
+  const { filters, setQuery, toggleStatus, togglePrioSort, toggleView, clear } = useFilters();
+  const [toast, setToast] = useState<string | null>(null);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showToast = (msg: string) => {
+    setToast(msg);
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    toastTimer.current = setTimeout(() => setToast(null), 1600);
+  };
+
+  useShortcuts(
+    {
+      onNewProject: () => showToast("novo projeto — chega na fase 2.4"),
+      onToggleView: toggleView,
+      onToggleTheme: () => showToast("tema completo na fase 3.4"),
+      onHelp: () =>
+        showToast("p projeto · n tarefa · 1-5 filtros · k kanban · t tema · ? ajuda · esc limpa"),
+      onClearFilters: clear,
+      onFocusAdd: () => {},
+      onFilterStatus: toggleStatus,
+    },
+    { isModalOpen: () => false },
+  );
+
+  const counts = countByStatus(projetos);
+
   return (
-    <main className="mx-auto flex min-h-screen max-w-5xl flex-col px-4 py-6">
-      <header className="flex items-baseline gap-2">
-        <h1 className="text-sm font-bold tracking-tight">
-          ops<span className="text-emerald-400">/</span>board
-        </h1>
-        <span className="text-[10px] text-zinc-500">scaffold — board chega nas próximas fases</span>
-      </header>
-      <div className="mt-24 border border-dashed border-zinc-600 rounded-md p-10 text-center text-zinc-500">
-        <span className="block text-2xl">_</span>
-        <p className="mt-3">nenhum projeto na fila.</p>
+    <div className="min-h-screen bg-[#0a0d12] text-zinc-300">
+      <Topbar
+        query={filters.query}
+        view={filters.view}
+        isDark
+        onQueryChange={setQuery}
+        onClearQuery={() => setQuery("")}
+        onToggleView={toggleView}
+        onToggleTheme={() => showToast("tema completo na fase 3.4")}
+        onNewProject={() => showToast("novo projeto — chega na fase 2.4")}
+      />
+      <div className="mx-auto max-w-5xl px-4 pb-2">
+        <FilterChips
+          counts={counts}
+          blockedCount={blockedCount(projetos)}
+          active={filters.status}
+          filtering={!!filters.query || !!filters.status}
+          onToggleStatus={toggleStatus}
+          onClear={clear}
+        />
       </div>
-    </main>
+      <div className="mx-auto max-w-5xl px-4 pb-2">
+        <Stats projetos={projetos} filters={filters} onTogglePrioSort={togglePrioSort} />
+      </div>
+
+      <main className="mx-auto max-w-5xl px-4 py-6">
+        <div className="border border-dashed border-zinc-700 rounded-lg p-10 text-center text-zinc-600">
+          <span className="block text-2xl">_</span>
+          <p className="mt-3">nenhum projeto na fila.</p>
+          <button
+            type="button"
+            onClick={() => showToast("novo projeto — chega na fase 2.4")}
+            className="mt-4 px-3 py-1.5 rounded-md bg-emerald-400 text-[#0a0d12] text-xs font-bold"
+          >
+            + criar primeiro projeto
+          </button>
+        </div>
+      </main>
+
+      {toast && (
+        <div className="fixed bottom-5 left-1/2 -translate-x-1/2 z-50 bg-[#1c2532] border border-zinc-600 text-zinc-300 text-xs px-4 py-2 rounded-md shadow-lg">
+          {toast}
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/components/client/FilterChips.tsx
+++ b/src/components/client/FilterChips.tsx
@@ -1,0 +1,59 @@
+import type { StatusFilter } from "@/lib/filter";
+import type { Status } from "@/lib/types";
+import { STATUS_LABEL } from "@/lib/types";
+
+export interface ChipDef {
+  key: StatusFilter;
+  label: string;
+  cls: string;
+}
+
+const CHIPS: ChipDef[] = [
+  { key: "todo", label: "todo", cls: "text-slate-400" },
+  { key: "doing", label: "doing", cls: "text-cyan-400" },
+  { key: "waiting", label: "waiting", cls: "text-amber-400" },
+  { key: "done", label: "done", cls: "text-emerald-400" },
+  { key: "blocked", label: "bloq", cls: "text-red-400" },
+];
+
+interface FilterChipsProps {
+  counts: Record<Status, number>;
+  blockedCount: number;
+  active: StatusFilter;
+  filtering: boolean;
+  onToggleStatus: (status: StatusFilter) => void;
+  onClear: () => void;
+}
+
+export function FilterChips({ counts, blockedCount, active, filtering, onToggleStatus, onClear }: FilterChipsProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="filtros por status">
+      {CHIPS.map(({ key, label, cls }) => {
+        const count = key === "blocked" ? blockedCount : counts[key as Status];
+        const isActive = active === key;
+        return (
+          <button
+            key={key}
+            type="button"
+            onClick={() => onToggleStatus(key)}
+            title={`filtra: ${key === "blocked" ? "bloqueadas" : STATUS_LABEL[key as Status]}`}
+            className={`chip ${cls} ${isActive ? "border-current" : ""} ${isActive ? "" : "opacity-60"}`}
+          >
+            {label}
+            <span className="opacity-60">{count}</span>
+          </button>
+        );
+      })}
+      {filtering && (
+        <button
+          type="button"
+          onClick={onClear}
+          className="chip font-bold text-zinc-400"
+          title="limpar filtros (status + busca)"
+        >
+          ✕ limpar
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/client/Stats.test.tsx
+++ b/src/components/client/Stats.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Stats } from "../../components/client/Stats";
+import { defaultFilters, type Filters } from "../../lib/filter";
+import { todayISO } from "../../lib/date";
+import type { Project } from "../../lib/types";
+
+const projeto = (tasks: Project["sections"][number]["tasks"]): Project => ({
+  id: "p1",
+  title: "A",
+  blocked: false,
+  sections: [{ id: "s1", title: "geral", tasks, notes: "", collapsed: false }],
+});
+
+const task = (over: Partial<Project["sections"][number]["tasks"][number]> = {}): Project["sections"][number]["tasks"][number] => ({
+  id: "t1",
+  text: "x",
+  status: "todo" as const,
+  note: "",
+  blocked: false,
+  prio: 3,
+  due: "",
+  doneAt: null,
+  ...over,
+});
+
+describe("Stats", () => {
+  it("mostra total, pendentes, concluídas com % e feitas hoje", () => {
+    render(
+      <Stats
+        projetos={[
+          projeto([
+            task(),
+            task({ id: "t2", status: "doing" }),
+            task({ id: "t3", status: "done", doneAt: todayISO() + "T09:00:00.000Z" }),
+          ]),
+        ]}
+        filters={defaultFilters}
+        onTogglePrioSort={() => {}}
+      />,
+    );
+    expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.getByText("(33%)")).toBeTruthy();
+    expect(screen.getByText("+1")).toBeTruthy();
+  });
+
+  it("casa 0% sem tarefas concluídas", () => {
+    render(
+      <Stats
+        projetos={[projeto([task()])]}
+        filters={defaultFilters}
+        onTogglePrioSort={() => {}}
+      />,
+    );
+    expect(screen.getByText("(0%)")).toBeTruthy();
+  });
+
+  it("toggle de prioridade invoca callback", async () => {
+    const onTogglePrioSort = vi.fn();
+    render(
+      <Stats projetos={[projeto([])]} filters={defaultFilters} onTogglePrioSort={onTogglePrioSort} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "↕ prio" }));
+    expect(onTogglePrioSort).toHaveBeenCalledTimes(1);
+  });
+
+  it("destaca dica de kanban quando em kanban", () => {
+    const f: Filters = { ...defaultFilters, view: "kanban" };
+    render(<Stats projetos={[]} filters={f} onTogglePrioSort={() => {}} />);
+    expect(screen.getByText(/kanban: arraste/i)).toBeTruthy();
+  });
+});

--- a/src/components/client/Stats.tsx
+++ b/src/components/client/Stats.tsx
@@ -1,0 +1,58 @@
+import { countByStatus, doneTodayCount } from "@/lib/selectors";
+import type { Project } from "@/lib/types";
+import type { Filters } from "@/lib/filter";
+import { todayISO } from "@/lib/date";
+
+interface StatsProps {
+  projetos: Project[];
+  filters: Filters;
+  onTogglePrioSort: () => void;
+}
+
+const fmtPct = (done: number, total: number) => (total ? Math.round((done / total) * 100) : 0);
+
+export function Stats({ projetos, filters, onTogglePrioSort }: StatsProps) {
+  const counts = countByStatus(projetos);
+  const done = counts.done;
+  const total = Object.values(counts).reduce((a, b) => a + b, 0);
+  const pendentes = total - done;
+  const doneToday = doneTodayCount(projetos);
+
+  const pct = fmtPct(done, total);
+
+  const hint =
+    filters.view === "kanban"
+      ? "kanban: arraste cartão pra coluna p/ mudar status"
+      : "status-dock: arraste tarefas p/ mudar status";
+
+  return (
+    <div className="text-[11px] text-zinc-500 flex flex-wrap gap-x-4 gap-y-1" role="status">
+      <span>
+        <span className="text-zinc-700">total</span>{" "}
+        <span className="font-bold text-zinc-200">{total}</span>
+      </span>
+      <span>
+        <span className="text-zinc-700">pendentes</span>{" "}
+        <span className="text-amber-400">{pendentes}</span>
+      </span>
+      <span>
+        <span className="text-zinc-700">concluídas</span>{" "}
+        <span className="text-emerald-400">{done}</span>{" "}
+        <span className="text-zinc-700">({pct}%)</span>
+      </span>
+      <span>
+        <span className="text-zinc-700">hoje</span>{" "}
+        <span className="text-emerald-400">+{doneToday}</span>
+      </span>
+      <button
+        type="button"
+        onClick={onTogglePrioSort}
+        className={`chip ${filters.prioSort ? "text-amber-400 border-current" : "text-zinc-500"}`}
+        title="ordenar por prioridade (P1 no topo)"
+      >
+        ↕ prio
+      </button>
+      <span className="ml-auto text-zinc-600 hidden sm:inline">{hint}</span>
+    </div>
+  );
+}

--- a/src/components/client/Topbar.tsx
+++ b/src/components/client/Topbar.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState } from "react";
+import type { View } from "@/lib/filter";
+
+interface TopbarProps {
+  query: string;
+  view: View;
+  isDark: boolean;
+  onQueryChange: (q: string) => void;
+  onClearQuery: () => void;
+  onToggleView: () => void;
+  onToggleTheme: () => void;
+  onNewProject: () => void;
+}
+
+const DEBOUNCE_MS = 200;
+
+export function Topbar({
+  query,
+  view,
+  isDark,
+  onQueryChange,
+  onClearQuery,
+  onToggleView,
+  onToggleTheme,
+  onNewProject,
+}: TopbarProps) {
+  const [draft, setDraft] = useState(query);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    setDraft(query);
+  }, [query]);
+
+  useEffect(() => {
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => onQueryChange(draft), DEBOUNCE_MS);
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draft]);
+
+  return (
+    <header className="sticky top-0 z-30 border-b border-zinc-800 bg-[#0a0d12]/95 backdrop-blur">
+      <div className="mx-auto max-w-5xl px-4 py-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-6">
+        <div className="flex items-center justify-between gap-4">
+          <h1 className="text-sm font-bold tracking-tight text-zinc-200">
+            ops<span className="text-emerald-400">/</span>board
+          </h1>
+          <div className="flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={onToggleTheme}
+              className="chip"
+              title="alternar tema claro/escuro (t)"
+            >
+              {isDark ? "☾" : "☀"}
+            </button>
+            <button
+              type="button"
+              onClick={onToggleView}
+              className="chip"
+              title="alternar lista/kanban (k)"
+            >
+              {view === "list" ? "kanban" : "lista"}
+            </button>
+            <button type="button" onClick={onNewProject} className="chip text-emerald-400 border-zinc-700">
+              <span className="mr-1 text-emerald-400">+</span>projeto
+            </button>
+          </div>
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <label className="block relative flex items-center gap-2">
+            <span className="text-emerald-400 font-bold text-xs" aria-hidden>
+              &gt;
+            </span>
+            <input
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              className="w-full flex-1 min-w-0 bg-[#0b1016] border border-zinc-800 rounded-md px-2.5 py-1.5 text-xs text-zinc-300 outline-none focus:border-emerald-500/50"
+              type="search"
+              placeholder="grep tarefas..."
+              autoComplete="off"
+              spellCheck={false}
+              aria-label="buscar tarefas"
+            />
+            {query && (
+              <button
+                type="button"
+                onClick={onClearQuery}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-zinc-600 hover:text-zinc-300 cursor-pointer select-none"
+                title="limpar busca"
+                aria-label="limpar busca"
+              >
+                x
+              </button>
+            )}
+          </label>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/hooks/useFilters.test.tsx
+++ b/src/hooks/useFilters.test.tsx
@@ -1,0 +1,66 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useFilters } from "./useFilters";
+
+describe("useFilters", () => {
+  it("mantém filtros default", () => {
+    const { result } = renderHook(() => useFilters());
+    expect(result.current.filters).toEqual({
+      query: "",
+      status: null,
+      prioSort: false,
+      view: "list",
+    });
+  });
+
+  it("setQuery atualiza e preserva o resto", () => {
+    const { result } = renderHook(() => useFilters());
+    act(() => result.current.setQuery("relatório"));
+    expect(result.current.filters.query).toBe("relatório");
+    expect(result.current.filters.status).toBeNull();
+  });
+
+  it("toggleStatus alterna e desliga ao repetir", () => {
+    const { result } = renderHook(() => useFilters());
+    act(() => result.current.toggleStatus("doing"));
+    expect(result.current.filters.status).toBe("doing");
+    act(() => result.current.toggleStatus("doing"));
+    expect(result.current.filters.status).toBeNull();
+  });
+
+  it("troca entre status diferentes", () => {
+    const { result } = renderHook(() => useFilters());
+    act(() => result.current.toggleStatus("todo"));
+    act(() => result.current.toggleStatus("done"));
+    expect(result.current.filters.status).toBe("done");
+  });
+
+  it("toggleView alterna lista/kanban", () => {
+    const { result } = renderHook(() => useFilters());
+    act(() => result.current.toggleView());
+    expect(result.current.filters.view).toBe("kanban");
+    act(() => result.current.toggleView());
+    expect(result.current.filters.view).toBe("list");
+  });
+
+  it("togglePrioSort alterna", () => {
+    const { result } = renderHook(() => useFilters());
+    act(() => result.current.togglePrioSort());
+    expect(result.current.filters.prioSort).toBe(true);
+  });
+
+  it("clear limpa query e status, preserva view e prioSort", () => {
+    const { result } = renderHook(() => useFilters());
+    act(() => {
+      result.current.setQuery("x");
+      result.current.toggleStatus("todo");
+      result.current.toggleView();
+      result.current.togglePrioSort();
+    });
+    act(() => result.current.clear());
+    expect(result.current.filters.query).toBe("");
+    expect(result.current.filters.status).toBeNull();
+    expect(result.current.filters.view).toBe("kanban");
+    expect(result.current.filters.prioSort).toBe(true);
+  });
+});

--- a/src/hooks/useFilters.ts
+++ b/src/hooks/useFilters.ts
@@ -1,0 +1,28 @@
+import { useCallback, useState } from "react";
+import { defaultFilters, type Filters, type StatusFilter, type View } from "../lib/filter";
+
+export function useFilters(initial: Filters = defaultFilters) {
+  const [filters, setFilters] = useState<Filters>(initial);
+
+  const setQuery = useCallback((query: string) => {
+    setFilters((f) => ({ ...f, query }));
+  }, []);
+
+  const toggleStatus = useCallback((status: StatusFilter) => {
+    setFilters((f) => ({ ...f, status: f.status === status ? null : status }));
+  }, []);
+
+  const togglePrioSort = useCallback(() => {
+    setFilters((f) => ({ ...f, prioSort: !f.prioSort }));
+  }, []);
+
+  const toggleView = useCallback(() => {
+    setFilters((f) => ({ ...f, view: (f.view === "list" ? "kanban" : "list") as View }));
+  }, []);
+
+  const clear = useCallback(() => {
+    setFilters((f) => ({ ...f, query: "", status: null }));
+  }, []);
+
+  return { filters, setQuery, toggleStatus, togglePrioSort, toggleView, clear };
+}

--- a/src/hooks/useShortcuts.test.tsx
+++ b/src/hooks/useShortcuts.test.tsx
@@ -1,0 +1,109 @@
+import { act, renderHook } from "@testing-library/react";
+import { fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useShortcuts } from "./useShortcuts";
+
+const handlers = () => ({
+  onNewProject: vi.fn(),
+  onToggleView: vi.fn(),
+  onToggleTheme: vi.fn(),
+  onHelp: vi.fn(),
+  onClearFilters: vi.fn(),
+  onFocusAdd: vi.fn(),
+  onFilterStatus: vi.fn(),
+});
+
+const press = (key: string) => {
+  fireEvent.keyDown(window, { key });
+};
+
+describe("useShortcuts", () => {
+  it("p abre novo projeto", () => {
+    const h = handlers();
+    renderHook(() => useShortcuts(h));
+    act(() => press("p"));
+    expect(h.onNewProject).toHaveBeenCalledTimes(1);
+  });
+
+  it("k alterna vista e t alterna tema", () => {
+    const h = handlers();
+    renderHook(() => useShortcuts(h));
+    act(() => press("k"));
+    expect(h.onToggleView).toHaveBeenCalledTimes(1);
+    act(() => press("t"));
+    expect(h.onToggleTheme).toHaveBeenCalledTimes(1);
+  });
+
+  it("? dispara ajuda", () => {
+    const h = handlers();
+    renderHook(() => useShortcuts(h));
+    act(() => press("?"));
+    expect(h.onHelp).toHaveBeenCalledTimes(1);
+  });
+
+  it("esc limpa filtros", () => {
+    const h = handlers();
+    renderHook(() => useShortcuts(h));
+    act(() => press("Escape"));
+    expect(h.onClearFilters).toHaveBeenCalledTimes(1);
+  });
+
+  it("n foca adicionar tarefa", () => {
+    const h = handlers();
+    renderHook(() => useShortcuts(h));
+    act(() => press("n"));
+    expect(h.onFocusAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it("1-5 passam o status correspondente", () => {
+    const h = handlers();
+    renderHook(() => useShortcuts(h));
+    act(() => press("1"));
+    expect(h.onFilterStatus).toHaveBeenCalledWith("todo");
+    act(() => press("2"));
+    expect(h.onFilterStatus).toHaveBeenCalledWith("doing");
+    act(() => press("3"));
+    expect(h.onFilterStatus).toHaveBeenCalledWith("waiting");
+    act(() => press("4"));
+    expect(h.onFilterStatus).toHaveBeenCalledWith("done");
+    act(() => press("5"));
+    expect(h.onFilterStatus).toHaveBeenCalledWith("blocked");
+  });
+
+  it("ignora teclas quando digitando em input", () => {
+    const h = handlers();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    renderHook(() => useShortcuts(h));
+    act(() => press("p"));
+    expect(h.onNewProject).not.toHaveBeenCalled();
+    input.remove();
+  });
+
+  it("ignora quando modal está aberto (exceto esc que fecha)", () => {
+    const h = handlers();
+    renderHook(() => useShortcuts(h, { isModalOpen: () => true }));
+    act(() => press("p"));
+    act(() => press("1"));
+    expect(h.onNewProject).not.toHaveBeenCalled();
+    expect(h.onFilterStatus).not.toHaveBeenCalled();
+  });
+
+  it("ignora combinações com ctrl/meta/alt", () => {
+    const h = handlers();
+    renderHook(() => useShortcuts(h));
+    fireEvent.keyDown(window, { key: "p", ctrlKey: true });
+    fireEvent.keyDown(window, { key: "p", metaKey: true });
+    fireEvent.keyDown(window, { key: "p", altKey: true });
+    expect(h.onNewProject).not.toHaveBeenCalled();
+  });
+
+  it("remove listener ao desmontar", () => {
+    const h = handlers();
+    const { unmount } = renderHook(() => useShortcuts(h));
+    unmount();
+    act(() => press("p"));
+    expect(h.onNewProject).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -1,0 +1,65 @@
+import { useEffect } from "react";
+import type { StatusFilter } from "../lib/filter";
+
+export interface ShortcutHandlers {
+  onNewProject: () => void;
+  onToggleView: () => void;
+  onToggleTheme: () => void;
+  onHelp: () => void;
+  onClearFilters: () => void;
+  onFocusAdd: () => void;
+  onFilterStatus: (status: StatusFilter) => void;
+}
+
+const STATUS_KEYS: StatusFilter[] = ["todo", "doing", "waiting", "done", "blocked"];
+
+export function useShortcuts(h: ShortcutHandlers, opts?: { isModalOpen?: () => boolean }) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const target = document.activeElement as HTMLElement | null;
+      const tag = target?.tagName;
+      const typing =
+        tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target?.isContentEditable;
+      if (typing) return;
+
+      const modalOpen = opts?.isModalOpen?.() ?? false;
+
+      if (e.key === "Escape" && !modalOpen) {
+        h.onClearFilters();
+        return;
+      }
+      if (e.key === "?" && !e.ctrlKey && !e.metaKey) {
+        h.onHelp();
+        return;
+      }
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+      if (modalOpen) return;
+
+      const k = e.key.toLowerCase();
+      switch (k) {
+        case "p":
+          e.preventDefault();
+          h.onNewProject();
+          break;
+        case "k":
+          e.preventDefault();
+          h.onToggleView();
+          break;
+        case "t":
+          h.onToggleTheme();
+          break;
+        case "n":
+          e.preventDefault();
+          h.onFocusAdd();
+          break;
+        default:
+          if (/^[1-5]$/.test(k)) {
+            e.preventDefault();
+            h.onFilterStatus(STATUS_KEYS[Number(k) - 1]);
+          }
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [h, opts?.isModalOpen]);
+}

--- a/src/lib/filter.test.ts
+++ b/src/lib/filter.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { isFiltering, matchTask, projMatches, sectMatches, type Filters } from "./filter";
+import type { Project, Section, Task } from "./types";
+
+const task = (over: Partial<Task> = {}): Task => ({
+  id: "t1",
+  text: "Enviar relatório pro cliente",
+  status: "todo",
+  note: "",
+  blocked: false,
+  prio: 3,
+  due: "",
+  doneAt: null,
+  ...over,
+});
+
+const section = (over: Partial<Section> = {}): Section => ({
+  id: "s1",
+  title: "geral",
+  tasks: [task()],
+  notes: "",
+  collapsed: false,
+  ...over,
+});
+
+const project = (over: Partial<Project> = {}): Project => ({
+  id: "p1",
+  title: "Projeto Alfa",
+  blocked: false,
+  sections: [section()],
+  ...over,
+});
+
+const none: Filters = { query: "", status: null, prioSort: false, view: "list" };
+
+describe("matchTask", () => {
+  it("casa qualquer tarefa sem filtros", () => {
+    expect(matchTask(task(), none)).toBe(true);
+  });
+
+  it("busca por texto ignorando maiúsculas, incluindo nota", () => {
+    expect(matchTask(task({ text: "Enviar relatório" }), { ...none, query: "RELATÓRIO" })).toBe(true);
+    expect(matchTask(task({ text: "x", note: "detalhe importante" }), { ...none, query: "IMPORTANTE" })).toBe(true);
+    expect(matchTask(task({ text: "x" }), { ...none, query: "nada" })).toBe(false);
+  });
+
+  it("filtra por status", () => {
+    expect(matchTask(task({ status: "doing" }), { ...none, status: "doing" })).toBe(true);
+    expect(matchTask(task({ status: "todo" }), { ...none, status: "doing" })).toBe(false);
+  });
+
+  it("filtra por bloqueada", () => {
+    expect(matchTask(task({ blocked: true }), { ...none, status: "blocked" })).toBe(true);
+    expect(matchTask(task({ blocked: false }), { ...none, status: "blocked" })).toBe(false);
+  });
+
+  it("combina status e query (ambos devem casar)", () => {
+    expect(
+      matchTask(task({ status: "waiting", text: "aguardando retorno" }), { ...none, status: "waiting", query: "aguardando" }),
+    ).toBe(true);
+    expect(
+      matchTask(task({ status: "waiting", text: "aguardando retorno" }), { ...none, status: "waiting", query: "relatório" }),
+    ).toBe(false);
+  });
+});
+
+describe("sectMatches", () => {
+  it("casa qualquer seção sem filtros", () => {
+    expect(sectMatches(section(), none)).toBe(true);
+  });
+
+  it("casa seção cujo título ou notas contêm a query", () => {
+    expect(sectMatches(section({ title: "história", notes: "fluxo do workspace" }), { ...none, query: "workspace" })).toBe(true);
+    expect(sectMatches(section({ title: "história" }), { ...none, query: "história" })).toBe(true);
+    expect(sectMatches(section({ title: "geral" }), { ...none, query: "inexistente" })).toBe(false);
+  });
+});
+
+describe("projMatches", () => {
+  it("casa qualquer projeto sem filtros", () => {
+    expect(projMatches(project(), none)).toBe(true);
+  });
+
+  it("casa projeto com seção correspondente (tarefa ou título/notas)", () => {
+    const p = project({
+      sections: [
+        section(),
+        section({ id: "s2", title: "história", tasks: [], notes: "DataLake" }),
+      ],
+    });
+    expect(projMatches(p, { ...none, query: "relatório" })).toBe(true);
+    expect(projMatches(p, { ...none, query: "DataLake" })).toBe(true);
+    expect(projMatches(p, { ...none, query: "sumiço" })).toBe(false);
+  });
+
+  it("não casa projeto sem seções correspondentes", () => {
+    const p = project({ sections: [section({ tasks: [task({ text: "a" })] })] });
+    expect(projMatches(p, { ...none, status: "doing" })).toBe(false);
+  });
+});
+
+describe("isFiltering", () => {
+  it("false sem query e sem status", () => {
+    expect(isFiltering(none)).toBe(false);
+  });
+  it("true com query ou status", () => {
+    expect(isFiltering({ ...none, query: "x" })).toBe(true);
+    expect(isFiltering({ ...none, status: "todo" })).toBe(true);
+    expect(isFiltering({ ...none, status: "blocked" })).toBe(true);
+  });
+});

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -1,0 +1,38 @@
+import type { Project, Section, Status, Task } from "./types";
+
+export type View = "list" | "kanban";
+export type StatusFilter = Status | "blocked" | null;
+
+export interface Filters {
+  query: string;
+  status: StatusFilter;
+  prioSort: boolean;
+  view: View;
+}
+
+export const defaultFilters: Filters = { query: "", status: null, prioSort: false, view: "list" };
+
+export const isFiltering = (f: Filters): boolean => !!f.query || !!f.status;
+
+export function matchTask(t: Task, f: Filters): boolean {
+  if (f.status === "blocked" && !t.blocked) return false;
+  if (f.status && f.status !== "blocked" && t.status !== f.status) return false;
+  if (!f.query) return true;
+  const q = f.query.toLowerCase();
+  return (t.text + " " + (t.note || "")).toLowerCase().includes(q);
+}
+
+const titleNotesMatch = (s: Section, query: string): boolean =>
+  (s.title + " " + s.notes).toLowerCase().includes(query.toLowerCase());
+
+/** Seção visível: tem tarefa que casa (status/query) ou título/notas casam com a query. */
+export function sectMatches(s: Section, f: Filters): boolean {
+  if (s.tasks.some((t) => matchTask(t, f))) return true;
+  return !!f.query && titleNotesMatch(s, f.query);
+}
+
+/** Projeto visível: alguma seção visível. */
+export function projMatches(p: Project, f: Filters): boolean {
+  if (!isFiltering(f)) return true;
+  return p.sections.some((s) => sectMatches(s, f));
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,17 @@
+import { fileURLToPath, URL } from "node:url";
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
   test: {
     environment: "jsdom",
-    include: ["src/**/*.test.ts"],
+    globals: true,
+    setupFiles: ["@testing-library/jest-dom/vitest"],
+    include: ["src/**/*.test.{ts,tsx}"],
   },
 });


### PR DESCRIPTION
Closes #3

- **Topbar**: busca com debounce (200ms), toggle vista/tema, novo projeto — componentizado e testável via props
- **Stats**: total, pendentes, concluídas (%), feitas hoje, ordenação por prioridade
- **FilterChips**: status + bloqueadas + limpar, counts reais do store
- **lib/filter**: `matchTask` / `sectMatches` / `projMatches` — seção só casa via query de título/notas quando há query
- **hooks**: `useFilters` (estado de filtro), `useShortcuts` (ignora input/modal/ctrl-alt-meta, esc fecha modal)
- **TDD**: 33 testes novos (60 no total), todos vistos falhar primeiro
- page.tsx monta o shell real com dados do store (empty state preservado)

Smoke: render verificado no navegador, console limpo.