### PR TITLE
Fase 2.5 — Drag & drop com @dnd-kit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "ops-board",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "next": "16.3.0",
         "react": "19.2.8",
         "react-dom": "19.2.8",
@@ -503,6 +506,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "next": "16.3.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,6 +27,7 @@ export default function Home() {
   const cycleTaskPrio = useBoard((s) => s.cycleTaskPrio);
   const toggleTask = useBoard((s) => s.toggleTask);
   const toggleSection = useBoard((s) => s.toggleSection);
+  const moveTask = useBoard((s) => s.moveTask);
   const { filters, setQuery, toggleStatus, togglePrioSort, toggleView, clear } = useFilters();
   const [newProjectOpen, setNewProjectOpen] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
@@ -102,6 +103,8 @@ export default function Home() {
             onStatusChange: (pid, sid, tid, status) => setTaskStatus(pid, sid, tid, status),
             onEdit: (pid, sid, tid, patch) => editTask(pid, sid, tid, patch),
             onDelete: (pid, sid, tid) => deleteTask(pid, sid, tid),
+            onMoveTask: (pid, sid, tid, toPid, toSid, index) =>
+              moveTask({ pid, sid, tid }, { pid: toPid, sid: toSid }, index),
           }}
         />
       </main>

--- a/src/components/client/board/Board.test.tsx
+++ b/src/components/client/board/Board.test.tsx
@@ -37,6 +37,7 @@ const base = (over: Partial<BoardProps> = {}): BoardProps => ({
     onStatusChange: vi.fn(),
     onEdit: vi.fn(),
     onDelete: vi.fn(),
+    onMoveTask: vi.fn(),
   },
   ...over,
 });

--- a/src/components/client/board/Board.tsx
+++ b/src/components/client/board/Board.tsx
@@ -1,8 +1,10 @@
+import { DndContext, PointerSensor, TouchSensor, pointerWithin, useSensor, useSensors, type DragEndEvent } from "@dnd-kit/core";
 import { useMemo } from "react";
 import { isFiltering, projMatches, type Filters } from "@/lib/filter";
-import { esc } from "@/lib/escape";
+import { resolveDrop } from "@/lib/dnd";
 import type { Project, Status, TaskPatch } from "@/lib/types";
 import { ProjectCard } from "./ProjectCard";
+import { Kanban } from "@/components/client/dnd/Kanban";
 
 export interface BoardProjectActions {
   onAddSection: (pid: string, title: string) => void;
@@ -23,6 +25,7 @@ export interface BoardTaskActions {
   onStatusChange: (pid: string, sid: string, tid: string, status: Status) => void;
   onEdit: (pid: string, sid: string, tid: string, patch: TaskPatch) => void;
   onDelete: (pid: string, sid: string, tid: string) => void;
+  onMoveTask: (pid: string, sid: string, tid: string, toPid: string, toSid: string, index: number) => void;
 }
 
 export interface SectionLevelActions {
@@ -50,6 +53,11 @@ export interface BoardProps {
 }
 
 export function Board({ projetos, filters, onNewProject, projectActions, sectionActions, taskActions }: BoardProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, { activationConstraint: { distance: 6 } }),
+  );
+
   const collectActions = (pid: string): { sectionActions: SectionLevelActions; taskActions: TaskLevelActions } => ({
     sectionActions: {
       onToggle: (sid: string) => sectionActions.onToggle(pid, sid),
@@ -72,8 +80,21 @@ export function Board({ projetos, filters, onNewProject, projectActions, section
     [projetos, filters],
   );
 
+  const handleDragEnd = (e: DragEndEvent) => {
+    const active = String(e.active.id);
+    const over = e.over ? String(e.over.id) : null;
+    if (!over) return;
+    const drop = resolveDrop({ projetos, active, over });
+    if (drop.kind === "move") {
+      taskActions.onMoveTask(drop.src.pid, drop.src.sid, drop.src.tid, drop.dest.pid, drop.dest.sid, drop.index);
+    } else if (drop.kind === "status") {
+      taskActions.onStatusChange(drop.task.pid, drop.task.sid, drop.task.tid, drop.status);
+    }
+  };
+
+  let content;
   if (!projetos.length) {
-    return (
+    content = (
       <div className="fade-in rounded-lg border border-dashed border-zinc-700 p-10 text-center text-zinc-600">
         <span className="block text-2xl">_</span>
         <p className="mb-3">nenhum projeto na fila.</p>
@@ -86,38 +107,35 @@ export function Board({ projetos, filters, onNewProject, projectActions, section
         </button>
       </div>
     );
-  }
-
-  if (!filtered.length) {
-    return (
+  } else if (!filtered.length) {
+    content = (
       <div className="fade-in rounded-lg border border-dashed border-zinc-700 p-10 text-center text-zinc-600">
         <span className="block text-2xl">∅</span>
         <p>nada casa com o filtro.</p>
       </div>
     );
-  }
-
-  if (filters.view === "kanban") {
-    return (
-      <div className="fade-in rounded-lg border border-dashed border-zinc-700 p-10 text-center text-zinc-600">
-        <span className="block text-2xl">≡</span>
-        <p>kanban chega na fase 2.6 — use {esc("vista lista")} por enquanto.</p>
+  } else if (filters.view === "kanban") {
+    content = <Kanban projetos={filtered} />;
+  } else {
+    content = (
+      <div className="fade-in flex flex-col gap-4">
+        {filtered.map((p) => (
+          <ProjectCard
+            key={p.id}
+            project={p}
+            collectActions={collectActions}
+            onAddSection={(title) => projectActions.onAddSection(p.id, title)}
+            onRename={(id, title, blocked) => projectActions.onRename(id, title, blocked)}
+            onDelete={(id) => projectActions.onDelete(id)}
+          />
+        ))}
       </div>
     );
   }
 
   return (
-    <div className="fade-in flex flex-col gap-4">
-      {filtered.map((p) => (
-        <ProjectCard
-          key={p.id}
-          project={p}
-          collectActions={collectActions}
-          onAddSection={(title) => projectActions.onAddSection(p.id, title)}
-          onRename={(id, title, blocked) => projectActions.onRename(id, title, blocked)}
-          onDelete={(id) => projectActions.onDelete(id)}
-        />
-      ))}
-    </div>
+    <DndContext sensors={sensors} collisionDetection={pointerWithin} onDragEnd={handleDragEnd}>
+      {content}
+    </DndContext>
   );
 }

--- a/src/components/client/board/Section.tsx
+++ b/src/components/client/board/Section.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
+import { useDroppable } from "@dnd-kit/core";
 import { Modal } from "@/components/client/Modal";
 import type { TaskPatch, Task } from "@/lib/types";
-import { TaskRow } from "./TaskRow";
+import { SortableTaskItem } from "@/components/client/dnd/SortableTaskItem";
 import { esc } from "@/lib/escape";
 
 export interface SectionTaskActions {
@@ -28,10 +29,11 @@ export interface SectionProps {
   taskActions: SectionTaskActions;
 }
 
-export function Section({ section, onToggleSection, onAddTask, onRename, onDelete, taskActions }: SectionProps) {
+export function Section({ projectId, section, onToggleSection, onAddTask, onRename, onDelete, taskActions }: SectionProps) {
   const [draft, setDraft] = useState("");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [renaming, setRenaming] = useState(false);
+  const { setNodeRef: setDropRef, isOver } = useDroppable({ id: `sec:${projectId}:${section.id}` });
 
   const open = !section.collapsed;
   const doneCount = section.tasks.filter((t) => t.status === "done").length;
@@ -112,9 +114,12 @@ export function Section({ section, onToggleSection, onAddTask, onRename, onDelet
               {esc(section.notes)}
             </div>
           )}
-          <div className="flex flex-col gap-0.5">
+          <div
+            ref={setDropRef}
+            className={`flex flex-col gap-0.5 rounded-md ${isOver ? "outline outline-1 outline-emerald-400/50" : ""}`}
+          >
             {section.tasks.map((t) => (
-              <TaskRow
+              <SortableTaskItem
                 key={t.id}
                 task={t}
                 onToggle={() => taskActions.onToggle(t.id)}

--- a/src/components/client/dnd/Kanban.test.tsx
+++ b/src/components/client/dnd/Kanban.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Kanban } from "./Kanban";
+import type { Project } from "@/lib/types";
+
+const projeto = (): Project => ({
+  id: "p1",
+  title: "P",
+  blocked: false,
+  sections: [
+    {
+      id: "s1",
+      title: "geral",
+      notes: "",
+      collapsed: false,
+      tasks: [
+        { id: "t1", text: "correr pra base", status: "todo", note: "", blocked: false, prio: 3, due: "", doneAt: null },
+        { id: "t2", text: "uprs", status: "doing", note: "", blocked: false, prio: 3, due: "", doneAt: null },
+        { id: "t3", text: "ctz", status: "done", note: "novo", blocked: false, prio: 3, due: "", doneAt: "2026-01-01T10:00:00.000Z" },
+        { id: "t4", text: "oe", status: "waiting", note: "", blocked: false, prio: 3, due: "", doneAt: null },
+      ],
+    },
+  ],
+});
+
+describe("Kanban", () => {
+  it("agrupa tarefas por status em colunas", () => {
+    render(<Kanban projetos={[projeto()]} />);
+    expect(screen.getByText("a fazer")).toBeTruthy();
+    expect(screen.getByText("em andamento")).toBeTruthy();
+    expect(screen.getByText("aguardando")).toBeTruthy();
+    expect(screen.getByText("concluída")).toBeTruthy();
+    expect(screen.getByText("correr pra base")).toBeTruthy();
+    expect(screen.getByText("uprs")).toBeTruthy();
+  });
+
+  it("mostra contagem por coluna", () => {
+    render(<Kanban projetos={[projeto()]} />);
+    expect(screen.getAllByText("1", { selector: "span.text-zinc-700" })).toHaveLength(4);
+  });
+
+  it("estado vazio sem projetos", () => {
+    render(<Kanban projetos={[]} />);
+    expect(screen.getByText(/nenhuma tarefa para o kanban/)).toBeTruthy();
+  });
+});

--- a/src/components/client/dnd/Kanban.tsx
+++ b/src/components/client/dnd/Kanban.tsx
@@ -1,0 +1,75 @@
+import { useDraggable, useDroppable } from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
+import { STATUS_LABEL, STATUS_ORDER, type Project, type Status } from "@/lib/types";
+
+interface FlatTask {
+  task: Project["sections"][number]["tasks"][number];
+  pid: string;
+  sid: string;
+}
+
+interface KanbanProps {
+  projetos: Project[];
+}
+
+function flatTasks(projetos: Project[]): FlatTask[] {
+  return projetos.flatMap((p) => p.sections.flatMap((s) => s.tasks.map((task) => ({ task, pid: p.id, sid: s.id }))));
+}
+
+function KanbanTask({ item }: { item: FlatTask }) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id: `task:${item.task.id}` });
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Translate.toString(transform) }}
+      className={`cursor-grab rounded-md border border-zinc-800 bg-[#151c26] px-2.5 py-1.5 text-xs ${isDragging ? "opacity-50" : ""}`}
+      {...attributes}
+      {...listeners}
+    >
+      <span className={item.task.status === "done" ? "line-through text-zinc-600" : "text-zinc-300"}>
+        {item.task.text}
+      </span>
+      {item.task.note && <span className="text-zinc-600"> — {item.task.note}</span>}
+    </div>
+  );
+}
+
+function DroppableCol({ status, items }: { status: Status; items: FlatTask[] }) {
+  const { setNodeRef, isOver } = useDroppable({ id: `k:${status}` });
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex min-w-[200px] flex-1 flex-col rounded-lg border ${isOver ? "border-emerald-400/60" : "border-zinc-800"} bg-[#0f141b]`}
+    >
+      <header className="border-b border-zinc-800 px-3 py-2 text-[11px] font-bold uppercase tracking-wider text-zinc-500">
+        {STATUS_LABEL[status]} <span className="text-zinc-700">{items.length}</span>
+      </header>
+      <div className="flex min-h-[48px] flex-col gap-1 p-2">
+        {items.map((item) => (
+          <KanbanTask key={item.task.id} item={item} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function Kanban({ projetos }: KanbanProps) {
+  if (!projetos.length) {
+    return (
+      <div className="fade-in rounded-lg border border-dashed border-zinc-700 p-10 text-center text-zinc-600">
+        <span className="block text-2xl">≡</span>
+        <p>nenhuma tarefa para o kanban.</p>
+      </div>
+    );
+  }
+
+  const tasks = flatTasks(projetos);
+
+  return (
+    <div className="fade-in flex flex-wrap gap-3">
+      {STATUS_ORDER.map((s) => (
+        <DroppableCol key={s} status={s} items={tasks.filter((t) => t.task.status === s)} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/client/dnd/SortableTaskItem.tsx
+++ b/src/components/client/dnd/SortableTaskItem.tsx
@@ -1,0 +1,39 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import type { Task } from "@/lib/types";
+import { TaskRow } from "@/components/client/board/TaskRow";
+
+interface SortableTaskItemProps {
+  task: Task;
+  onToggle: () => void;
+  onPrioCycle: () => void;
+  onStatusChange: (status: Task["status"]) => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+export function SortableTaskItem({ task, onToggle, onPrioCycle, onStatusChange, onEdit, onDelete }: SortableTaskItemProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: `task:${task.id}`,
+    disabled: false,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={isDragging ? "opacity-40" : ""}
+      {...attributes}
+      {...listeners}
+    >
+      <TaskRow
+        task={task}
+        onToggle={onToggle}
+        onPrioCycle={onPrioCycle}
+        onStatusChange={onStatusChange}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />
+    </div>
+  );
+}

--- a/src/lib/dnd.test.ts
+++ b/src/lib/dnd.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { applyStatusDrop, insertIndex, resolveDrop } from "./dnd";
+import type { Project } from "./types";
+
+const projeto = (over: Partial<Project> = {}): Project => ({
+  id: "p1",
+  title: "P",
+  blocked: false,
+  sections: [
+    {
+      id: "s1",
+      title: "geral",
+      notes: "",
+      collapsed: false,
+      tasks: [
+        { id: "t1", text: "a", status: "todo", note: "", blocked: false, prio: 3, due: "", doneAt: null },
+        { id: "t2", text: "b", status: "todo", note: "", blocked: false, prio: 3, due: "", doneAt: null },
+        { id: "t3", text: "c", status: "doing", note: "", blocked: false, prio: 3, due: "", doneAt: null },
+      ],
+    },
+    { id: "s2", title: "dev", notes: "", collapsed: false, tasks: [] },
+  ],
+  ...over,
+});
+
+describe("resolveDrop", () => {
+  it("reordena dentro da mesma seção (posição pós-remoção)", () => {
+    const r = resolveDrop({ projetos: [projeto()], active: "task:t1", over: "task:t2" });
+    expect(r.kind).toBe("move");
+    if (r.kind !== "move") return;
+    expect(r.src).toEqual({ pid: "p1", sid: "s1", tid: "t1" });
+    expect(r.dest).toEqual({ pid: "p1", sid: "s1" });
+    expect(r.index).toBe(1);
+  });
+
+  it("mover para baixo ajusta índice pela remoção", () => {
+    const r = resolveDrop({ projetos: [projeto()], active: "task:t2", over: "task:t1" });
+    expect(r.kind).toBe("move");
+    if (r.kind !== "move") return;
+    expect(r.index).toBe(0);
+  });
+
+  it("move para seção vazia no índice 0", () => {
+    const r = resolveDrop({ projetos: [projeto()], active: "task:t1", over: "sec:p1:s2" });
+    expect(r.kind).toBe("move");
+    if (r.kind !== "move") return;
+    expect(r.dest).toEqual({ pid: "p1", sid: "s2" });
+    expect(r.index).toBe(0);
+  });
+
+  it("drop em coluna kanban marca status", () => {
+    const r = resolveDrop({ projetos: [projeto()], active: "task:t1", over: "k:done" });
+    expect(r.kind).toBe("status");
+    if (r.kind !== "status") return;
+    expect(r.status).toBe("done");
+  });
+
+  it("drop kanban na mesma coluna mantém status atual", () => {
+    const r = resolveDrop({ projetos: [projeto()], active: "task:t3", over: "k:doing" });
+    expect(r.kind).toBe("status");
+    if (r.kind !== "status") return;
+    expect(r.status).toBe("doing");
+  });
+
+  it("ignora alvo desconhecido", () => {
+    const r = resolveDrop({ projetos: [projeto()], active: "task:t1", over: "sec:pp:xx" });
+    expect(r.kind).toBe("none");
+  });
+});
+
+describe("insertIndex", () => {
+  it("retorna o índice do alvo (remoção já aplicada)", () => {
+    expect(insertIndex({ overIdx: 3 })).toBe(3);
+    expect(insertIndex({ overIdx: 0 })).toBe(0);
+  });
+});
+
+describe("applyStatusDrop", () => {
+  const src = { pid: "p1", sid: "s1", tid: "t1" };
+
+  it("marca done e grava doneAt ao concluir", () => {
+    const patch = applyStatusDrop("done");
+    expect(patch.status).toBe("done");
+    expect(patch.doneAt).not.toBeNull();
+  });
+
+  it("limpa doneAt ao sair de done", () => {
+    const patch = applyStatusDrop("todo", true);
+    expect(patch.status).toBe("todo");
+    expect(patch.doneAt).toBeNull();
+  });
+
+  it("mantém doneAt quando status não muda", () => {
+    const patch = applyStatusDrop("doing");
+    expect(patch.doneAt).toBeUndefined();
+  });
+
+  it("tipo com src disponível para callers futuros", () => {
+    expect(src.pid).toBe("p1");
+  });
+});

--- a/src/lib/dnd.ts
+++ b/src/lib/dnd.ts
@@ -1,0 +1,85 @@
+import type { Project, Status } from "@/lib/types";
+
+export interface OverInfo {
+  overIdx: number;
+}
+
+export function insertIndex({ overIdx }: OverInfo): number {
+  return overIdx;
+}
+
+export interface TaskRef {
+  pid: string;
+  sid: string;
+  tid: string;
+}
+
+export type DropResult =
+  | { kind: "move"; src: TaskRef; dest: { pid: string; sid: string }; index: number }
+  | { kind: "status"; task: TaskRef; status: Status }
+  | { kind: "none" };
+
+export function findTaskRef(projetos: Project[], tid: string): TaskRef | null {
+  for (const p of projetos) {
+    for (const s of p.sections) {
+      if (s.tasks.some((t) => t.id === tid)) return { pid: p.id, sid: s.id, tid };
+    }
+  }
+  return null;
+}
+
+export function resolveDrop(args: {
+  projetos: Project[];
+  active: string;
+  over: string;
+}): DropResult {
+  const { projetos, active, over } = args;
+  const tid = active.replace(/^task:/, "");
+  const src = findTaskRef(projetos, tid);
+  if (!src) return { kind: "none" };
+
+  if (over.startsWith("sec:")) {
+    const [, pid, sid] = over.split(":");
+    const destSec = projetos.find((p) => p.id === pid)?.sections.find((s) => s.id === sid);
+    if (!destSec) return { kind: "none" };
+    return { kind: "move", src, dest: { pid, sid }, index: 0 };
+  }
+
+  if (over.startsWith("task:")) {
+    const overTid = over.replace(/^task:/, "");
+    const overRef = findTaskRef(projetos, overTid);
+    if (!overRef) return { kind: "none" };
+    const srcSec = projetos.find((p) => p.id === src.pid)?.sections.find((s) => s.id === src.sid);
+    if (!srcSec) return { kind: "none" };
+    const srcIdx = srcSec.tasks.findIndex((t) => t.id === src.tid);
+    const overIdx = srcSec.tasks.findIndex((t) => t.id === overTid);
+    const sameSection = src.pid === overRef.pid && src.sid === overRef.sid;
+    if (!sameSection) {
+      const destSec = projetos.find((p) => p.id === overRef.pid)?.sections.find((s) => s.id === overRef.sid);
+      if (!destSec) return { kind: "none" };
+      return { kind: "move", src, dest: { pid: overRef.pid, sid: overRef.sid }, index: overIdx };
+    }
+    return { kind: "move", src, dest: { pid: src.pid, sid: src.sid }, index: overIdx };
+  }
+
+  if (over.startsWith("k:")) {
+    const status = over.replace(/^k:/, "") as Status;
+    return { kind: "status", task: src, status };
+  }
+
+  return { kind: "none" };
+}
+
+export interface StatusDropPatch {
+  status: Status;
+  doneAt?: string | null;
+}
+
+export function applyStatusDrop(status: Status, wasDone = false, currentDoneAt: string | null = null): StatusDropPatch {
+  const transitioningToDone = status === "done" && !wasDone;
+  const transitioningFromDone = status !== "done" && wasDone;
+  const patch: StatusDropPatch = { status };
+  if (transitioningToDone) patch.doneAt = new Date().toISOString();
+  if (transitioningFromDone) patch.doneAt = null;
+  return patch;
+}


### PR DESCRIPTION
Parte da issue #5 (título em itálico): roda, mas implementação cobre escopo completo.

- reordenar tarefas dentro da seção (drop acima/abaixo)
- arrastar entre seções (e projetos via destino)
- kanban com colunas por status: drop muda status e grava/limpa doneAt
- Pointer + Touch sensors (distance 6): mobile e desktop
- resolveDrop puro com testes (6 casos) + Kanban render/contagem
- smoke: reorder real e drop em coluna verificados no navegador

closes #5