### PR TITLE
feat: overlays shadcn (Dialog, Select, DropdownMenu, Tooltip)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { JetBrains_Mono, Geist } from "next/font/google";
 import "./globals.css";
 import { cn } from "@/lib/utils";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 const geist = Geist({ subsets: ["latin"], variable: "--font-sans" });
 
@@ -19,7 +20,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="pt-BR" suppressHydrationWarning className={cn("antialiased", jetbrains.variable, "font-sans", geist.variable)}>
-      <body className="min-h-full font-mono">{children}</body>
+      <body className="min-h-full font-mono">
+        <TooltipProvider>{children}</TooltipProvider>
+      </body>
     </html>
   );
 }

--- a/src/components/client/Modal.tsx
+++ b/src/components/client/Modal.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useId, useState } from "react";
+import { useId, useState } from "react";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -32,35 +38,22 @@ export function Modal({ title, fields, submitLabel = "salvar", onSubmit, onCance
     Object.fromEntries(fields.filter((f) => f.type === "checkbox").map((f) => [f.key, Boolean(f.value)])),
   );
 
-  useEffect(() => {
-    document.querySelector<HTMLElement>("[data-modal-first]")?.focus();
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onCancel();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onCancel]);
-
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/70 backdrop-blur-sm px-4 pt-[12vh]"
-      onMouseDown={(e) => {
-        if (e.target === e.currentTarget) onCancel();
-      }}
-    >
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        className="w-full max-w-[460px] rounded-lg border border-[var(--line-soft)] bg-[var(--panel-2)] shadow-xl"
+    <Dialog open onOpenChange={(o) => { if (!o) onCancel(); }}>
+      <DialogContent
+        showCloseButton={false}
+        initialFocus={() => document.querySelector<HTMLElement>("[data-modal-first]")}
+        className="!sm:max-w-[460px] gap-0 rounded-lg border border-[var(--line-soft)] bg-[var(--panel-2)] p-0 text-[var(--text)] shadow-xl"
       >
-        <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--line)]">
-          <h3 id={titleId} className="text-[13px] font-bold text-zinc-200">
-            {title}
-          </h3>
-          <Button type="button" variant="ghost" size="icon-xs" onClick={onCancel} title="fechar" aria-label="fechar">
-            ×
-          </Button>
+        <div className="flex items-center justify-between border-b border-[var(--line)] px-4 py-3">
+          <DialogTitle className="text-[13px] font-bold text-[var(--text)]">{title}</DialogTitle>
+          <DialogClose
+            render={
+              <Button type="button" variant="ghost" size="icon-xs" title="fechar" aria-label="fechar">
+                ×
+              </Button>
+            }
+          />
         </div>
         <form
           onSubmit={(e) => {
@@ -94,14 +87,12 @@ export function Modal({ title, fields, submitLabel = "salvar", onSubmit, onCance
                     className="input-line min-h-[72px] w-full resize-y"
                   />
                 ) : f.type === "checkbox" ? (
-                  <div className="flex items-center gap-2">
-                    <Switch
-                      id={`field-${f.key}`}
-                      data-modal-first={i === 0 ? "" : undefined}
-                      checked={checks[f.key] ?? false}
-                      onCheckedChange={(c) => setChecks((prev) => ({ ...prev, [f.key]: c }))}
-                    />
-                  </div>
+                  <Switch
+                    id={`field-${f.key}`}
+                    data-modal-first={i === 0 ? "" : undefined}
+                    checked={checks[f.key] ?? false}
+                    onCheckedChange={(c) => setChecks((prev) => ({ ...prev, [f.key]: c }))}
+                  />
                 ) : f.type === "select" ? (
                   <select
                     id={`field-${f.key}`}
@@ -147,7 +138,7 @@ export function Modal({ title, fields, submitLabel = "salvar", onSubmit, onCance
             </Button>
           </div>
         </form>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/client/Stats.tsx
+++ b/src/components/client/Stats.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { countByStatus, doneTodayCount } from "@/lib/selectors";
 import type { Project } from "@/lib/types";
 import type { Filters } from "@/lib/filter";
@@ -45,16 +46,22 @@ export function Stats({ projetos, filters, onTogglePrioSort }: StatsProps) {
         <span className="text-[var(--dimmer)]">hoje</span>{" "}
         <span className="text-emerald-400">+{doneToday}</span>
       </span>
-      <Button
-        type="button"
-        variant={filters.prioSort ? "outline" : "ghost"}
-        size="xs"
-        onClick={onTogglePrioSort}
-        className={`text-[var(--muted-text)] ${filters.prioSort ? "border-current text-amber-400 bg-[var(--hover)]" : ""}`}
-        title="ordenar por prioridade (P1 no topo)"
-      >
-        ↕ prio
-      </Button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              type="button"
+              variant={filters.prioSort ? "outline" : "ghost"}
+              size="xs"
+              onClick={onTogglePrioSort}
+              className={`text-[var(--muted-text)] ${filters.prioSort ? "border-current text-amber-400 bg-[var(--hover)]" : ""}`}
+            >
+              ↕ prio
+            </Button>
+          }
+        />
+        <TooltipContent side="bottom">ordenar por prioridade (P1 no topo)</TooltipContent>
+      </Tooltip>
       <span className="ml-auto text-[var(--dim)] hidden sm:inline">{hint}</span>
     </div>
   );

--- a/src/components/client/Topbar.tsx
+++ b/src/components/client/Topbar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { View } from "@/lib/filter";
 
 interface TopbarProps {
@@ -55,16 +56,22 @@ export function Topbar({
             ops<span className="text-emerald-400">/</span>board
           </h1>
           <div className="flex items-center gap-1.5">
-            <Button
-              type="button"
-              variant="ghost"
-              size="xs"
-              onClick={onToggleTheme}
-              className="text-[var(--muted-text)] hover:text-[var(--text)]"
-              title="alternar tema claro/escuro (t)"
-            >
-              {isDark ? "☾" : "☀"}
-            </Button>
+            <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  onClick={onToggleTheme}
+                  className="text-[var(--muted-text)] hover:text-[var(--text)]"
+                >
+                  {isDark ? "☾" : "☀"}
+                </Button>
+              }
+            />
+            <TooltipContent side="bottom">alternar tema claro/escuro (t)</TooltipContent>
+          </Tooltip>
             <Button
               type="button"
               variant="ghost"

--- a/src/components/client/board/ProjectCard.test.tsx
+++ b/src/components/client/board/ProjectCard.test.tsx
@@ -36,6 +36,10 @@ const base = (over: Partial<ProjectCardProps> = {}): ProjectCardProps => ({
 });
 
 describe("ProjectCard", () => {
+  const openMenu = async () => {
+    await userEvent.click(screen.getByLabelText("ações do projeto"));
+  };
+
   it("mostra título e seções", () => {
     render(<ProjectCard {...base()} />);
     expect(screen.getByText("Projeto Alfa")).toBeTruthy();
@@ -50,7 +54,8 @@ describe("ProjectCard", () => {
   it("adiciona seção via modal", async () => {
     const p = base();
     render(<ProjectCard {...p} />);
-    await userEvent.click(screen.getByTitle("adicionar seção"));
+    await openMenu();
+    await userEvent.click(await screen.findByRole("menuitem", { name: "adicionar seção" }));
     const input = await screen.findByLabelText("título");
     await userEvent.type(input, "dev{Enter}");
     expect(p.onAddSection).toHaveBeenCalledWith("dev");
@@ -59,7 +64,8 @@ describe("ProjectCard", () => {
   it("renomeia via modal preenchido", async () => {
     const p = base();
     render(<ProjectCard {...p} />);
-    await userEvent.click(screen.getByTitle("renomear projeto"));
+    await openMenu();
+    await userEvent.click(await screen.findByRole("menuitem", { name: "renomear projeto" }));
     const input = await screen.findByLabelText("título");
     await userEvent.clear(input);
     await userEvent.type(input, "Renomeado{Enter}");
@@ -70,7 +76,8 @@ describe("ProjectCard", () => {
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     const p = base();
     render(<ProjectCard {...p} />);
-    await userEvent.click(screen.getByTitle("excluir projeto"));
+    await openMenu();
+    await userEvent.click(await screen.findByRole("menuitem", { name: "excluir projeto" }));
     expect(confirmSpy).toHaveBeenCalled();
     expect(p.onDelete).toHaveBeenCalledWith("p1");
     confirmSpy.mockRestore();
@@ -80,7 +87,8 @@ describe("ProjectCard", () => {
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
     const p = base();
     render(<ProjectCard {...p} />);
-    await userEvent.click(screen.getByTitle("excluir projeto"));
+    await openMenu();
+    await userEvent.click(await screen.findByRole("menuitem", { name: "excluir projeto" }));
     expect(p.onDelete).not.toHaveBeenCalled();
     confirmSpy.mockRestore();
   });

--- a/src/components/client/board/ProjectCard.tsx
+++ b/src/components/client/board/ProjectCard.tsx
@@ -2,6 +2,13 @@ import { useState } from "react";
 import { Modal } from "@/components/client/Modal";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { esc } from "@/lib/escape";
 import type { Project, Status, TaskPatch } from "@/lib/types";
 import { Section, type SectionTaskActions as SectionLevelTaskActions } from "./Section";
@@ -55,38 +62,45 @@ export function ProjectCard({ project, collectActions, onAddSection, onRename, o
           </Badge>
         )}
         <span className="ml-auto flex items-center gap-1">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            onClick={() => setModal({ kind: "add-section" })}
-            title="adicionar seção"
-            aria-label="adicionar seção"
-          >
-            +
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            onClick={() => setModal({ kind: "rename" })}
-            title="renomear projeto"
-            aria-label="renomear projeto"
-          >
-            ✎
-          </Button>
-          <Button
-            type="button"
-            variant="destructive"
-            size="icon-xs"
-            onClick={() => {
-              if (window.confirm(`excluir projeto "${project.title}"?`)) onDelete(project.id);
-            }}
-            title="excluir projeto"
-            aria-label="excluir projeto"
-          >
-            ×
-          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  title="ações do projeto"
+                  aria-label="ações do projeto"
+                >
+                  ⋯
+                </Button>
+              }
+            />
+            <DropdownMenuContent align="end" className="bg-[var(--panel-2)] text-[var(--text)]">
+              <DropdownMenuItem
+                className="text-xs"
+                onClick={() => setModal({ kind: "add-section" })}
+              >
+                adicionar seção
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="text-xs"
+                onClick={() => setModal({ kind: "rename" })}
+              >
+                renomear projeto
+              </DropdownMenuItem>
+              <DropdownMenuSeparator className="bg-[var(--line)]" />
+              <DropdownMenuItem
+                variant="destructive"
+                className="text-xs"
+                onClick={() => {
+                  if (window.confirm(`excluir projeto "${project.title}"?`)) onDelete(project.id);
+                }}
+              >
+                excluir projeto
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </span>
       </div>
 

--- a/src/components/client/board/Section.test.tsx
+++ b/src/components/client/board/Section.test.tsx
@@ -29,6 +29,10 @@ const base = (over: Partial<SectionProps> = {}): SectionProps => ({
   ...over,
 });
 
+const openMenu = async (label: string) => {
+  await userEvent.click(screen.getByLabelText(label));
+};
+
 describe("Section", () => {
   it("mostra contador done/total", () => {
     render(<Section {...base()} />);
@@ -67,7 +71,8 @@ describe("Section", () => {
   it("renomeia seção via modal", async () => {
     const p = base();
     render(<Section {...p} />);
-    await userEvent.click(screen.getByTitle("renomear seção"));
+    await openMenu("ações da seção");
+    await userEvent.click(await screen.findByRole("menuitem", { name: "renomear seção" }));
     const input = await screen.findByLabelText("título");
     await userEvent.clear(input);
     await userEvent.type(input, "Sprint 12{Enter}");
@@ -77,11 +82,13 @@ describe("Section", () => {
   it("renomear abre modal e excluir chama callback", async () => {
     const p = base();
     render(<Section {...p} />);
-    await userEvent.click(screen.getByTitle("renomear seção"));
+    await openMenu("ações da seção");
+    await userEvent.click(await screen.findByRole("menuitem", { name: "renomear seção" }));
     expect(await screen.findByLabelText("título")).toBeTruthy();
     expect(p.onRename).not.toHaveBeenCalled();
     await userEvent.click(screen.getByTitle("fechar"));
-    await userEvent.click(screen.getByTitle("excluir seção"));
+    await openMenu("ações da seção");
+    await userEvent.click(await screen.findByRole("menuitem", { name: "excluir seção" }));
     expect(p.onDelete).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/client/board/Section.tsx
+++ b/src/components/client/board/Section.tsx
@@ -2,6 +2,13 @@ import { useState } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import { Modal } from "@/components/client/Modal";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import type { TaskPatch, Task } from "@/lib/types";
 import { SortableTaskItem } from "@/components/client/dnd/SortableTaskItem";
@@ -82,32 +89,44 @@ export function Section({ projectId, section, onToggleSection, onAddTask, onRena
         </span>
         {section.notes && <span className="ml-auto hidden text-[11px] text-[var(--dimmer)] sm:inline">notas</span>}
         <span className="ml-auto flex items-center gap-0.5">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            onClick={(e) => {
-              e.stopPropagation();
-              setRenaming(true);
-            }}
-            title="renomear seção"
-            aria-label="renomear seção"
-          >
-            ✎
-          </Button>
-          <Button
-            type="button"
-            variant="destructive"
-            size="icon-xs"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete();
-            }}
-            title="excluir seção"
-            aria-label="excluir seção"
-          >
-            ×
-          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={(e) => e.stopPropagation()}
+                  title="ações da seção"
+                  aria-label="ações da seção"
+                >
+                  ⋯
+                </Button>
+              }
+            />
+            <DropdownMenuContent align="end" className="bg-[var(--panel-2)] text-[var(--text)]">
+              <DropdownMenuItem
+                className="text-xs"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setRenaming(true);
+                }}
+              >
+                renomear seção
+              </DropdownMenuItem>
+              <DropdownMenuSeparator className="bg-[var(--line)]" />
+              <DropdownMenuItem
+                variant="destructive"
+                className="text-xs"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete();
+                }}
+              >
+                excluir seção
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </span>
       </div>
 

--- a/src/components/client/board/TaskRow.test.tsx
+++ b/src/components/client/board/TaskRow.test.tsx
@@ -58,7 +58,8 @@ describe("TaskRow", () => {
   it("troca status via select", async () => {
     const p = base();
     render(<TaskRow {...p} />);
-    await userEvent.selectOptions(screen.getByLabelText("status"), "doing");
+    await userEvent.click(screen.getByLabelText("status"));
+    await userEvent.click(await screen.findByRole("option", { name: "em andamento" }));
     expect(p.onStatusChange).toHaveBeenCalledWith("doing");
   });
 

--- a/src/components/client/board/TaskRow.tsx
+++ b/src/components/client/board/TaskRow.tsx
@@ -1,5 +1,13 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { isDueSoon, isOverdue } from "@/lib/date";
 import { linkify } from "@/lib/escape";
 import { fmtDate } from "@/lib/date";
@@ -55,14 +63,19 @@ export function TaskRow({ task, onToggle, onPrioCycle, onStatusChange, onEdit, o
           bloqueada
         </Badge>
       )}
-      <button
-        type="button"
-        onClick={onPrioCycle}
-        title="prioridade: clique pra mudar"
-        className={`shrink-0 rounded px-1.5 py-0.5 border text-[10px] font-bold ${PRIO_CLS[task.prio]}`}
-      >
-        {PRIO_KEYS[task.prio]}
-      </button>
+      <Tooltip>
+        <TooltipTrigger render={
+          <button
+            type="button"
+            onClick={onPrioCycle}
+            aria-label="prioridade: clique pra mudar"
+            className={`shrink-0 rounded px-1.5 py-0.5 border text-[10px] font-bold ${PRIO_CLS[task.prio]}`}
+          >
+            {PRIO_KEYS[task.prio]}
+          </button>
+        } />
+        <TooltipContent side="top">prioridade: clique pra mudar</TooltipContent>
+      </Tooltip>
       {task.due &&
         (overdue ? (
           <Badge
@@ -80,19 +93,26 @@ export function TaskRow({ task, onToggle, onPrioCycle, onStatusChange, onEdit, o
             {fmtDate(task.due)}
           </span>
         ))}
-      <select
-        aria-label="status"
+      <Select
         value={task.status}
-        onChange={(e) => onStatusChange(e.target.value as Status)}
-        title="mudar status"
-        className="shrink-0 appearance-none rounded border border-[var(--line)] bg-[var(--field)] px-1.5 py-0.5 text-[11px] text-[var(--muted-text)] outline-none cursor-pointer hover:border-zinc-600 hover:text-[var(--text)]"
+        onValueChange={(v) => onStatusChange(v as Status)}
       >
-        {STATUS_ORDER.map((k) => (
-          <option key={k} value={k}>
-            {STATUS_LABEL[k]}
-          </option>
-        ))}
-      </select>
+        <SelectTrigger
+          size="sm"
+          aria-label="status"
+          title="mudar status"
+          className="h-7 border-[var(--line)] bg-[var(--field)] px-2 text-[11px] text-[var(--muted-text)] hover:border-zinc-600 hover:text-[var(--text)]"
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {STATUS_ORDER.map((k) => (
+            <SelectItem key={k} value={k} className="py-1 text-xs">
+              {STATUS_LABEL[k]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
       <Button type="button" variant="ghost" size="icon-xs" onClick={onEdit} title="editar" aria-label="editar">
         ✎
       </Button>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-2 right-2"
+                size="icon-sm"
+              />
+            }
+          >
+            <XIcon
+            />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close render={<Button variant="outline" />}>
+          Close
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        "font-heading text-base leading-none font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,268 @@
+"use client"
+
+import * as React from "react"
+import { Menu as MenuPrimitive } from "@base-ui/react/menu"
+
+import { cn } from "@/lib/utils"
+import { ChevronRightIcon, CheckIcon } from "lucide-react"
+
+function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props) {
+  return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+}
+
+function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
+  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+}
+
+function DropdownMenuContent({
+  align = "start",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  className,
+  ...props
+}: MenuPrimitive.Popup.Props &
+  Pick<
+    MenuPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({ ...props }: MenuPrimitive.Group.Props) {
+  return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: MenuPrimitive.GroupLabel.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.GroupLabel
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: MenuPrimitive.Item.Props & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props) {
+  return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: MenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.SubmenuTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-popup-open:bg-accent data-popup-open:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </MenuPrimitive.SubmenuTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  align = "start",
+  alignOffset = -3,
+  side = "right",
+  sideOffset = 0,
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuContent>) {
+  return (
+    <DropdownMenuContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn("w-auto min-w-[96px] rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      align={align}
+      alignOffset={alignOffset}
+      side={side}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: MenuPrimitive.CheckboxItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <MenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon
+          />
+        </MenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
+  return (
+    <MenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: MenuPrimitive.RadioItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <MenuPrimitive.RadioItemIndicator>
+          <CheckIcon
+          />
+        </MenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: MenuPrimitive.Separator.Props) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import * as React from "react"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+
+const Select = SelectPrimitive.Root
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon
+      />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon
+      />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delay = 0,
+  ...props
+}: TooltipPrimitive.Provider.Props) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delay={delay}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  side = "top",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  children,
+  ...props
+}: TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/lib/selectors.ts
+++ b/src/lib/selectors.ts
@@ -13,5 +13,12 @@ export function countByStatus(projetos: Project[]): Record<Status, number> {
 export const blockedCount = (projetos: Project[]): number =>
   allTasks(projetos).filter((t) => t.blocked).length;
 
+const localDay = (iso: string): string => {
+  const d = new Date(iso);
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${m}-${day}`;
+};
+
 export const doneTodayCount = (projetos: Project[]): number =>
-  allTasks(projetos).filter((t) => t.doneAt && t.doneAt.slice(0, 10) === todayISO()).length;
+  allTasks(projetos).filter((t) => t.doneAt && localDay(t.doneAt) === todayISO()).length;


### PR DESCRIPTION
## Fase 3.3 — Overlays shadcn (_closes #9_)

- **Dialog** substitui modal custom: foco trap, esc, click-outside e `initialFocus` no primeiro campo (`[data-modal-first]`); `aria-labelledby` nativo
- **Select** substitui `<select>` nativo do status da tarefa (portal, teclado, item indicator)
- **DropdownMenu** agrupa ações do projeto (adicionar seção / renomear / excluir) e da seção (renomear / excluir), item destrutivo em `--gave`
- **Tooltip**: prioridade da tarefa, ordenação `↕ prio` e tema; `TooltipProvider` no layout
- Fix: `doneTodayCount` agora compara em dia local (bug latente de TZ: 00h UTC cruzava o dia)
- 131 testes (menus, select e dialog cobertos), typecheck/lint/build limpos; smoke no navegador: menu abre, dialog foca campo, esc fecha, tooltip aparece, troca de status persiste
