### PR TITLE
Fase 4.1 — infra de testes + GitHub Actions como gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Unit + componentes
+        run: npm test
+
+      - name: Instalar navegadores Playwright
+        run: npx playwright install --with-deps chromium
+
+      - name: E2E
+        run: npm run e2e
+
+      - name: Upload report Playwright
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ npm install
 npm run dev        # http://localhost:3000
 npm run lint       # eslint
 npm run typecheck  # tsc --noEmit
+npm test           # unit + componentes (vitest)
+npm run e2e        # e2e (playwright, chromium; instala navegador na 1ª vez)
 npm run build      # produção
 ```
+
+PRs passam por CI (`.github/workflows/ci.yml`): lint, typecheck, testes e e2e precisam estar verdes para merge.
 
 A versão clássica (HTML/CSS/JS vanilla) vive em `legacy/` como referência de paridade durante a migração.
 

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+
+test("carrega o app e persiste dados no localStorage", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: /ops\/board/ })).toBeVisible();
+
+  await page.getByRole("button", { name: "+ criar primeiro projeto" }).click();
+  await page.getByLabel("título").fill("projeto-ci");
+  await page.getByRole("button", { name: "criar" }).click();
+  await expect(page.getByText("projeto-ci", { exact: true })).toBeVisible();
+
+  await page.reload();
+  await expect(page.getByText("projeto-ci", { exact: true })).toBeVisible();
+
+  const stored = await page.evaluate(() => localStorage.getItem("opsboard.v1"));
+  expect(stored).toContain("projeto-ci");
+});
+
+test("alternar tema persiste e sobrevive a reload", async ({ page }) => {
+  await page.goto("/");
+  const isLight = await page.evaluate(() =>
+    document.documentElement.classList.contains("light"),
+  );
+  const icon = isLight ? "☀" : "☾";
+  const expected = isLight ? "dark" : "light";
+
+  await page.getByRole("button", { name: icon }).click();
+  const stored = await page.evaluate(() => localStorage.getItem("opsboard.theme"));
+  expect(stored).toBe(expected);
+
+  await page.reload();
+  const after = await page.evaluate(() => localStorage.getItem("opsboard.theme"));
+  expect(after).toBe(stored);
+  await expect(page.getByRole("button", { name: expected === "light" ? "☀" : "☾" })).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "zustand": "^5.0.15"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^7.0.1",
         "@testing-library/react": "^16.3.2",
@@ -2269,6 +2270,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -8963,6 +8980,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@base-ui/react": "^1.7.0",
@@ -30,6 +31,7 @@
     "zustand": "^5.0.15"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["github"], ["list"]] : "list",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "npm run build && npm run start",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+});

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
## O que mudou

- **Playwright config** (`playwright.config.ts`): testDir `e2e/`, chromium, webServer `build && start`, retries em CI, trace on-first-retry, report github em CI.
- **`npm run e2e`** e primeiro spec (`e2e/smoke.spec.ts`): fluxo de criação de projeto + persistência no localStorage (`opsboard.v1`) e tema (next-themes) sobrevive a reload.
- **CI gate** (`.github/workflows/ci.yml`): em todo PR/push — lint, typecheck, `npm test` (vitest) e `npm run e2e` (chromium com `--with-deps`), artefato do report em falha.
- **README**: `npm test` e `npm run e2e` documentados + nota sobre CI como requisito de merge.

## Verificação

- Local: 130 testes vitest, typecheck 0, lint 0 erros, build ok, e2e 2/2 (webServer real + chromium).
- Scripts adicionados sem quebrar os existentes.

Closes #11