### PR TITLE
Fase 4.3 — testes de componente (store, board, tarefa, diálogo)

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import Home from "@/app/page";
+
+describe("criação de projeto (integração página)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("não cria projeto quando o título é vazio", async () => {
+    const user = userEvent.setup();
+    render(<Home />);
+    await user.click(screen.getByRole("button", { name: "+ criar primeiro projeto" }));
+    await user.click(screen.getByRole("button", { name: "criar" }));
+    expect(screen.getByRole("button", { name: "+ criar primeiro projeto" })).toBeInTheDocument();
+  });
+
+  it("cria projeto preenchido no modal", async () => {
+    const user = userEvent.setup();
+    render(<Home />);
+    await user.click(screen.getByRole("button", { name: "+ criar primeiro projeto" }));
+    await user.type(screen.getByLabelText("título"), "projeto-ci");
+    await user.click(screen.getByRole("button", { name: "criar" }));
+    expect(screen.getByText("projeto-ci")).toBeInTheDocument();
+  });
+});

--- a/src/components/client/Stats.test.tsx
+++ b/src/components/client/Stats.test.tsx
@@ -71,4 +71,24 @@ describe("Stats", () => {
     render(<Stats projetos={[]} filters={f} onTogglePrioSort={() => {}} />);
     expect(screen.getByText(/kanban: arraste/i)).toBeTruthy();
   });
+
+  it("expõe contadores por data-testid estável", () => {
+    render(
+      <Stats
+        projetos={[
+          projeto([
+            task(),
+            task({ id: "t2", status: "doing" }),
+            task({ id: "t3", status: "done", doneAt: todayISO() + "T09:00:00.000Z" }),
+          ]),
+        ]}
+        filters={defaultFilters}
+        onTogglePrioSort={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("stat-total")).toHaveTextContent("3");
+    expect(screen.getByTestId("stat-pending")).toHaveTextContent("2");
+    expect(screen.getByTestId("stat-done")).toHaveTextContent("1");
+    expect(screen.getByTestId("stat-today")).toHaveTextContent("+1");
+  });
 });

--- a/src/components/client/Stats.tsx
+++ b/src/components/client/Stats.tsx
@@ -31,20 +31,20 @@ export function Stats({ projetos, filters, onTogglePrioSort }: StatsProps) {
     <div className="text-[11px] text-[var(--muted-text)] flex flex-wrap gap-x-4 gap-y-1" role="status">
       <span>
         <span className="text-[var(--dimmer)]">total</span>{" "}
-        <span className="font-bold text-[var(--text)]">{total}</span>
+        <span data-testid="stat-total" className="font-bold text-[var(--text)]">{total}</span>
       </span>
       <span>
         <span className="text-[var(--dimmer)]">pendentes</span>{" "}
-        <span className="text-amber-400">{pendentes}</span>
+        <span data-testid="stat-pending" className="text-amber-400">{pendentes}</span>
       </span>
       <span>
         <span className="text-[var(--dimmer)]">concluídas</span>{" "}
-        <span className="text-emerald-400">{done}</span>{" "}
+        <span data-testid="stat-done" className="text-emerald-400">{done}</span>{" "}
         <span className="text-[var(--dimmer)]">({pct}%)</span>
       </span>
       <span>
         <span className="text-[var(--dimmer)]">hoje</span>{" "}
-        <span className="text-emerald-400">+{doneToday}</span>
+        <span data-testid="stat-today" className="text-emerald-400">+{doneToday}</span>
       </span>
       <Tooltip>
         <TooltipTrigger

--- a/src/components/client/board/TaskRow.test.tsx
+++ b/src/components/client/board/TaskRow.test.tsx
@@ -23,6 +23,11 @@ const base = (over: Partial<TaskRowProps["task"]> = {}): TaskRowProps => ({
 });
 
 describe("TaskRow", () => {
+  it("renderiza linha com data-testid estável", () => {
+    render(<TaskRow {...base()} />);
+    expect(screen.getByTestId("task-row")).toBeInTheDocument();
+  });
+
   it("renderiza texto com link e nota", () => {
     render(<TaskRow {...base()} />);
     const link = screen.getByRole("link", { name: "https://exemplo.com" });

--- a/src/components/client/board/TaskRow.tsx
+++ b/src/components/client/board/TaskRow.tsx
@@ -43,7 +43,10 @@ export function TaskRow({ task, onToggle, onPrioCycle, onStatusChange, onEdit, o
   const done = task.status === "done";
 
   return (
-    <div className={`flex items-center gap-2.5 rounded-md px-2 py-1.5 transition-colors hover:bg-[var(--hover)] ${done ? "" : ""}`}>
+    <div
+      data-testid="task-row"
+      className={`flex items-center gap-2.5 rounded-md px-2 py-1.5 transition-colors hover:bg-[var(--hover)] ${done ? "" : ""}`}
+    >
       <button
         type="button"
         onClick={onToggle}


### PR DESCRIPTION
## O que mudou

- **`data-testid` estáveis** nos pontos estruturais: `task-row`, `stat-total`, `stat-pending`, `stat-done`, `stat-today` — consultas não dependem de texto/posição.
- **Stats**: contadores expostos por testid (teste dedicado).
- **Integração de página** (novo `src/app/page.test.tsx`): fluxo real de criação de projeto pelo modal — título **vazio não cria** projeto (validação em `page.tsx`), título preenchido cria e lista.
- Estados principais já cobertos nos testes existentes (vazio, filtrado, bloqueado, vencido) — confirmados na auditoria; sem regressão.

## Verificação

- 156 testes passando (21 arquivos), typecheck 0, lint 0 erros, build ok, e2e 2/2.

Closes #13