### PR TITLE
Fase 4.4 — e2e de fluxos (CRUD, filtros, busca, kanban, atalhos, tema)

### DIFF
--- a/e2e/crud.spec.ts
+++ b/e2e/crud.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function createProject(page: Page, title: string) {
+  const empty = page.getByRole("button", { name: "+ criar primeiro projeto" });
+  if (await empty.isVisible()) {
+    await empty.click();
+  } else {
+    await page.getByRole("button", { name: "+ projeto" }).click();
+  }
+  await page.getByLabel("título").fill(title);
+  await page.getByRole("button", { name: "criar" }).click();
+}
+
+async function addSection(page: Page, title: string) {
+  await page.getByRole("button", { name: "ações do projeto", exact: true }).click();
+  await page.getByRole("menuitem", { name: "adicionar seção" }).click();
+  await page.getByLabel("título").fill(title);
+  await page.getByRole("button", { name: "criar" }).click();
+}
+
+async function addTask(page: Page, text: string) {
+  await page.getByLabel("nova tarefa").first().fill(text);
+  await page.getByLabel("nova tarefa").first().press("Enter");
+}
+
+test("cria projeto (com seção padrão), tarefas; persiste após reload", async ({ page }) => {
+  await page.goto("/");
+
+  await createProject(page, "webapp");
+  await expect(page.getByRole("heading", { name: "webapp" })).toBeVisible();
+  await expect(page.getByText("geral", { exact: true })).toHaveCount(1);
+
+  await addTask(page, "fazer café");
+  await addTask(page, "beber café");
+  await expect(page.getByText("fazer café", { exact: false })).toBeVisible();
+  await expect(page.getByText("beber café", { exact: false })).toBeVisible();
+
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "webapp" })).toBeVisible();
+  await expect(page.getByText("fazer café", { exact: false })).toBeVisible();
+  await expect(page.getByText("beber café", { exact: false })).toBeVisible();
+});
+
+test("adiciona seção extra, edita tarefa: texto, prioridade, vencimento, nota e bloqueada", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addSection(page, "backlog");
+  await expect(page.getByText("backlog", { exact: true })).toBeVisible();
+  await addTask(page, "tarefa antiga");
+
+  await page.getByTestId("task-row").getByRole("button", { name: "editar" }).click();
+  const dialog = page.getByRole("dialog", { name: "editar tarefa" });
+  await dialog.getByLabel("tarefa").fill("tarefa nova");
+  await dialog.getByLabel("prioridade").selectOption({ label: "P1 — urgente" });
+  await dialog.getByLabel("vencimento").fill("2026-08-14");
+  await dialog.getByLabel("nota").fill("detalhe da nota");
+  await dialog.getByRole("switch").click();
+  await page.getByRole("button", { name: "salvar" }).click();
+
+  await expect(page.getByText("tarefa nova", { exact: false })).toBeVisible();
+  await expect(page.getByText("detalhe da nota", { exact: false })).toBeVisible();
+  await expect(page.getByText("P1", { exact: true })).toBeVisible();
+  await expect(page.getByText("bloqueada", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "bloq 1" })).toBeVisible();
+});
+
+test("exclui tarefa, seção e projeto (com confirmação)", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "tarefa a");
+
+  await page.getByTestId("task-row").getByRole("button", { name: "excluir" }).click();
+  await expect(page.getByText("tarefa a", { exact: false })).toHaveCount(0);
+
+  await page.getByRole("button", { name: "ações da seção", exact: true }).click();
+  await page.getByRole("menuitem", { name: "excluir seção" }).click();
+  await expect(page.getByText("geral", { exact: true })).toHaveCount(0);
+
+  page.once("dialog", (dialog) => void dialog.accept());
+  await page.getByRole("button", { name: "ações do projeto", exact: true }).click();
+  await page.getByRole("menuitem", { name: "excluir projeto" }).click();
+  await expect(page.getByText("nenhum projeto na fila.")).toBeVisible();
+});
+
+test("renomeia projeto (e marca como bloqueado) e renomeia seção", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+
+  await page.getByRole("button", { name: "ações do projeto", exact: true }).click();
+  await page.getByRole("menuitem", { name: "renomear projeto" }).click();
+  await page.getByLabel("título").fill("prod");
+  await page.getByRole("switch").click();
+  await page.getByRole("button", { name: "salvar" }).click();
+  await expect(page.getByRole("heading", { name: "prod" })).toBeVisible();
+  await page.getByRole("button", { name: "ações da seção", exact: true }).click();
+  await page.getByRole("menuitem", { name: "renomear seção" }).click();
+  await page.getByLabel("título").fill("backlog");
+  await page.getByRole("button", { name: "salvar" }).click();
+  await expect(page.getByText("backlog", { exact: true })).toBeVisible();
+  await expect(page.getByText("geral", { exact: true })).toHaveCount(0);
+});

--- a/e2e/interactions.spec.ts
+++ b/e2e/interactions.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function createProject(page: Page, title: string) {
+  await page.getByRole("button", { name: "+ criar primeiro projeto" }).click();
+  await page.getByLabel("título").fill(title);
+  await page.getByRole("button", { name: "criar" }).click();
+}
+
+async function addTask(page: Page, text: string) {
+  await page.getByLabel("nova tarefa").first().fill(text);
+  await page.getByLabel("nova tarefa").first().press("Enter");
+}
+
+test("filtra por status no nível do projeto e limpa com esc", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "completado");
+  await addTask(page, "tarefa concluída");
+  await page.getByRole("combobox", { name: "status" }).click();
+  await page.getByRole("option", { name: "concluída" }).click();
+
+  await page.getByRole("button", { name: "+ projeto" }).click();
+  await page.getByLabel("título").fill("em aberto");
+  await page.getByRole("button", { name: "criar" }).click();
+  await addTask(page, "tarefa pendente");
+
+  await page.getByRole("button", { name: "done 1" }).click();
+  await expect(page.getByRole("heading", { name: "completado" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "em aberto" })).toHaveCount(0);
+
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("heading", { name: "em aberto" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "✕ limpar" })).toHaveCount(0);
+});
+
+test("busca por texto de tarefa e mostra vazio quando nada casa", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "relatório mensal");
+
+  await page.getByLabel("buscar tarefas").fill("relatório");
+  await expect(page.getByText("relatório mensal", { exact: false })).toBeVisible();
+
+  await page.getByLabel("buscar tarefas").fill("zumbi");
+  await expect(page.getByText("nada casa com o filtro.")).toBeVisible();
+
+  await page.getByRole("button", { name: "limpar busca" }).click();
+  await expect(page.getByText("relatório mensal", { exact: false })).toBeVisible();
+});
+
+test("kanban por status e volta para a lista (botão e atalho k)", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "na fila");
+  await addTask(page, "feita");
+  await page.getByRole("combobox", { name: "status" }).first().click();
+  await page.getByRole("option", { name: "concluída" }).click();
+
+  await page.getByRole("button", { name: "kanban" }).click();
+  await expect(page.getByText("a fazer 1", { exact: true })).toBeVisible();
+  await expect(page.getByText("concluída 1", { exact: true })).toBeVisible();
+
+  await page.keyboard.press("k");
+  await expect(page.getByRole("button", { name: "kanban" })).toBeVisible();
+  await expect(page.getByTestId("task-row")).toHaveCount(2);
+});
+
+test("atalhos: p abre projeto, 1 filtra todo, ? mostra ajuda, t alterna tema, esc limpa", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "pendencia");
+
+  await page.locator("body").click({ position: { x: 4, y: 4 } });
+  await page.keyboard.press("p");
+  await expect(page.getByLabel("título")).toBeVisible();
+  await page.getByLabel("título").fill("outro");
+  await page.getByRole("button", { name: "criar" }).click();
+  await expect(page.getByRole("heading", { name: "outro" })).toBeVisible();
+
+  await page.keyboard.press("1");
+  await expect(page.getByRole("button", { name: "todo 1" })).toHaveAttribute("aria-pressed", "true");
+
+  await page.keyboard.press("?");
+  await expect(page.getByText("p projeto · n tarefa · 1-5 filtros · k kanban · t tema · ? ajuda · esc limpa")).toBeVisible();
+
+  const html = page.locator("html");
+  await expect(html).toHaveClass(/light/);
+  await page.keyboard.press("t");
+  await expect(html).toHaveClass(/dark/);
+  await page.keyboard.press("t");
+  await expect(html).toHaveClass(/light/);
+
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("button", { name: "todo 1" })).toHaveAttribute("aria-pressed", "false");
+});
+
+test("ordena por prioridade (P1 no topo) com ↕ prio", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "tarefa b");
+  await addTask(page, "tarefa a");
+
+  const rows = page.getByTestId("task-row");
+  await expect(rows).toHaveCount(2);
+  await expect(rows.nth(0)).toContainText("tarefa b");
+  await expect(rows.nth(1)).toContainText("tarefa a");
+
+  await rows.nth(1).getByRole("button", { name: "prioridade: clique pra mudar" }).click();
+  await expect(rows.nth(1)).toContainText("P1");
+
+  await page.getByRole("button", { name: "↕ prio" }).click();
+  await expect(rows.nth(0)).toContainText("tarefa a");
+  await expect(rows.nth(1)).toContainText("tarefa b");
+});

--- a/src/components/client/board/Board.tsx
+++ b/src/components/client/board/Board.tsx
@@ -115,7 +115,7 @@ export function Board({ projetos, filters, onNewProject, projectActions, section
       </div>
     );
   } else if (filters.view === "kanban") {
-    content = <Kanban projetos={filtered} />;
+    content = <Kanban projetos={filtered} prioSort={filters.prioSort} />;
   } else {
     content = (
       <div className="fade-in flex flex-col gap-4">
@@ -127,6 +127,7 @@ export function Board({ projetos, filters, onNewProject, projectActions, section
             onAddSection={(title) => projectActions.onAddSection(p.id, title)}
             onRename={(id, title, blocked) => projectActions.onRename(id, title, blocked)}
             onDelete={(id) => projectActions.onDelete(id)}
+            prioSort={filters.prioSort}
           />
         ))}
       </div>

--- a/src/components/client/board/ProjectCard.tsx
+++ b/src/components/client/board/ProjectCard.tsx
@@ -28,7 +28,8 @@ export interface ProjectCardProps {
   };
   onAddSection: (title: string) => void;
   onRename: (id: string, title: string, blocked: boolean) => void;
-onDelete: (id: string) => void;
+  onDelete: (id: string) => void;
+  prioSort?: boolean;
 }
 
 type ModalState =
@@ -36,7 +37,7 @@ type ModalState =
   | { kind: "add-section" }
   | null;
 
-export function ProjectCard({ project, collectActions, onAddSection, onRename, onDelete }: ProjectCardProps) {
+export function ProjectCard({ project, collectActions, onAddSection, onRename, onDelete, prioSort }: ProjectCardProps) {
   const [modal, setModal] = useState<ModalState>(null);
   const actions = collectActions(project.id);
 
@@ -122,6 +123,7 @@ export function ProjectCard({ project, collectActions, onAddSection, onRename, o
             onRename={(title) => actions.sectionActions.onRename(s.id, title)}
             onDelete={() => actions.sectionActions.onDelete(s.id)}
             taskActions={secTaskActions}
+            prioSort={prioSort}
           />
         );
       })}

--- a/src/components/client/board/Section.tsx
+++ b/src/components/client/board/Section.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
+import { sortTasks } from "@/lib/filter";
 import type { TaskPatch, Task } from "@/lib/types";
 import { SortableTaskItem } from "@/components/client/dnd/SortableTaskItem";
 import { esc } from "@/lib/escape";
@@ -36,9 +37,10 @@ export interface SectionProps {
   onRename: (title: string) => void;
   onDelete: () => void;
   taskActions: SectionTaskActions;
+  prioSort?: boolean;
 }
 
-export function Section({ projectId, section, onToggleSection, onAddTask, onRename, onDelete, taskActions }: SectionProps) {
+export function Section({ projectId, section, onToggleSection, onAddTask, onRename, onDelete, taskActions, prioSort }: SectionProps) {
   const [draft, setDraft] = useState("");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [renaming, setRenaming] = useState(false);
@@ -141,7 +143,7 @@ export function Section({ projectId, section, onToggleSection, onAddTask, onRena
             ref={setDropRef}
             className={`flex flex-col gap-0.5 rounded-md ${isOver ? "outline outline-1 outline-emerald-400/50" : ""}`}
           >
-            {section.tasks.map((t) => (
+            {sortTasks(section.tasks, !!prioSort, (t) => t.prio).map((t) => (
               <SortableTaskItem
                 key={t.id}
                 task={t}

--- a/src/components/client/dnd/Kanban.tsx
+++ b/src/components/client/dnd/Kanban.tsx
@@ -1,5 +1,6 @@
 import { useDraggable, useDroppable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
+import { sortTasks } from "@/lib/filter";
 import { STATUS_LABEL, STATUS_ORDER, type Project, type Status } from "@/lib/types";
 
 interface FlatTask {
@@ -12,6 +13,7 @@ interface FlatTask {
 
 interface KanbanProps {
   projetos: Project[];
+  prioSort?: boolean;
 }
 
 function flatTasks(projetos: Project[]): FlatTask[] {
@@ -60,7 +62,7 @@ function DroppableCol({ status, items }: { status: Status; items: FlatTask[] }) 
   );
 }
 
-export function Kanban({ projetos }: KanbanProps) {
+export function Kanban({ projetos, prioSort }: KanbanProps) {
   if (!projetos.length) {
     return (
       <div className="fade-in rounded-lg border border-dashed border-[var(--line-soft)] p-10 text-center text-[var(--dim)]">
@@ -70,7 +72,7 @@ export function Kanban({ projetos }: KanbanProps) {
     );
   }
 
-  const tasks = flatTasks(projetos);
+  const tasks = sortTasks(flatTasks(projetos), !!prioSort, (i) => i.task.prio);
 
   return (
     <div className="fade-in flex flex-wrap gap-3">

--- a/src/lib/filter.test.ts
+++ b/src/lib/filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isFiltering, matchTask, projMatches, sectMatches, type Filters } from "./filter";
+import { isFiltering, matchTask, projMatches, sectMatches, sortTasks, type Filters } from "./filter";
 import type { Project, Section, Task } from "./types";
 
 const task = (over: Partial<Task> = {}): Task => ({
@@ -96,6 +96,32 @@ describe("projMatches", () => {
   it("não casa projeto sem seções correspondentes", () => {
     const p = project({ sections: [section({ tasks: [task({ text: "a" })] })] });
     expect(projMatches(p, { ...none, status: "doing" })).toBe(false);
+  });
+});
+
+describe("sortTasks", () => {
+  const mk = (prio: number, text: string) => ({ prio, text });
+
+  it("sem prioSort, retorna o mesmo array", () => {
+    const tasks = [mk(3, "a"), mk(1, "b")];
+    expect(sortTasks(tasks, false, (t) => t.prio)).toBe(tasks);
+  });
+
+  it("com prioSort, P1 no topo", () => {
+    const tasks = [mk(3, "a"), mk(1, "b"), mk(2, "c")];
+    expect(sortTasks(tasks, true, (t) => t.prio).map((t) => t.text)).toEqual(["b", "c", "a"]);
+  });
+
+  it("não muta o array original", () => {
+    const tasks = [mk(3, "a"), mk(1, "b")];
+    const out = sortTasks(tasks, true, (t) => t.prio);
+    expect(tasks.map((t) => t.prio)).toEqual([3, 1]);
+    expect(out).not.toBe(tasks);
+  });
+
+  it("empates preservam a ordem original (estável)", () => {
+    const tasks = [mk(1, "a"), mk(2, "b"), mk(1, "c")];
+    expect(sortTasks(tasks, true, (t) => t.prio).map((t) => t.text)).toEqual(["a", "c", "b"]);
   });
 });
 

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -36,3 +36,9 @@ export function projMatches(p: Project, f: Filters): boolean {
   if (!isFiltering(f)) return true;
   return p.sections.some((s) => sectMatches(s, f));
 }
+
+/** Ordena tarefas por prioridade (P1 no topo) quando prioSort; estável; não muta a origem. */
+export function sortTasks<T>(tasks: T[], prioSort: boolean, key: (t: T) => number): T[] {
+  if (!prioSort) return tasks;
+  return [...tasks].sort((a, b) => key(a) - key(b));
+}


### PR DESCRIPTION
## O que mudou

### `prioSort` passou a funcionar de verdade
- `sortTasks` novo em `src/lib/filter.ts` (ordenamento estável, P1 no topo, não muta a origem; testes unitários TDD — 4 casos)
- Aplicado na lista (`Section`) e no kanban (`Kanban`); antes o botão `↕ prio` só alternava estado sem ordenar nada

### E2E de fluxos (Playwright)
- `e2e/crud.spec.ts` — 4 fluxos:
  - criar projeto (seção padrão incluída), adicionar tarefas, persistência após reload
  - adicionar seção + editar tarefa completa (texto, prioridade, vencimento, nota, bloqueada)
  - excluir tarefa, seção e projeto (com confirmação de dialog)
  - renomear projeto (e marcar como bloqueado) e renomear seção
- `e2e/interactions.spec.ts` — 5 fluxos:
  - filtro por status + limpar com Escape
  - busca por texto e estado vazio
  - kanban ↔ lista (botão e atalho `k`)
  - atalhos `p`, `1`, `?`, `t`, `Escape`
  - ordenação por prioridade com `↕ prio`

## Verificação

- 160 testes vitest (21 arquivos) verdes
- 11 e2e verdes (Playwright, chromium)
- typecheck 0 erros, lint 0 erros, build OK
- CI (job `check`) roda tudo automaticamente neste PR

Close #14