### PR TITLE
Fase 4.5 — e2e: DnD, kanban, export/import e migração

### DIFF
--- a/e2e/dnd.spec.ts
+++ b/e2e/dnd.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+async function createProject(page: Page, title: string) {
+  const empty = page.getByRole("button", { name: "+ criar primeiro projeto" });
+  if (await empty.isVisible()) {
+    await empty.click();
+  } else {
+    await page.getByRole("button", { name: "+ projeto" }).click();
+  }
+  await page.getByLabel("título").fill(title);
+  await page.getByRole("button", { name: "criar" }).click();
+}
+
+async function addSection(page: Page, title: string) {
+  await page.getByRole("button", { name: "ações do projeto", exact: true }).click();
+  await page.getByRole("menuitem", { name: "adicionar seção" }).click();
+  await page.getByLabel("título").fill(title);
+  await page.getByRole("button", { name: "criar" }).click();
+}
+
+async function addTask(page: Page, text: string, section = 0) {
+  await page.getByLabel("nova tarefa").nth(section).fill(text);
+  await page.getByLabel("nova tarefa").nth(section).press("Enter");
+}
+
+async function drag(page: Page, src: Locator, dst: Locator) {
+  const sb = await src.boundingBox();
+  const db = await dst.boundingBox();
+  if (!sb || !db) throw new Error("bounding box indisponível");
+  await page.mouse.move(sb.x + sb.width / 2, sb.y + sb.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(sb.x + sb.width / 2 + 12, sb.y + sb.height / 2, { steps: 4 });
+  await page.mouse.move(db.x + db.width / 2, db.y + db.height / 2, { steps: 12 });
+  await page.mouse.up();
+}
+
+test("reordena tarefa dentro da seção por arrasto", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "primeira");
+  await addTask(page, "segunda");
+
+  const rows = page.getByTestId("task-row");
+  await expect(rows).toHaveCount(2);
+  await expect(rows.nth(0)).toContainText("primeira");
+  await expect(rows.nth(1)).toContainText("segunda");
+
+  await drag(page, rows.nth(1), rows.nth(0));
+
+  await expect(rows.nth(0)).toContainText("segunda");
+  await expect(rows.nth(1)).toContainText("primeira");
+});
+
+test("move tarefa entre seções por arrasto", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addSection(page, "backlog");
+  await addTask(page, "em geral", 0);
+  await addTask(page, "em backlog", 1);
+
+  await drag(page, page.getByTestId("task-row").first(), page.getByTestId("task-row").nth(1));
+
+  await expect(page.getByText("0/0", { exact: true })).toBeVisible();
+  await expect(page.getByText("0/2", { exact: true })).toBeVisible();
+  await expect(page.getByTestId("task-row")).toHaveCount(2);
+});
+
+test("muda status via kanban: arrasta para a coluna concluída e dispara confete", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "na fila");
+
+  await page.getByRole("button", { name: "kanban" }).click();
+  await expect(page.getByText("a fazer 1", { exact: true })).toBeVisible();
+
+  await drag(page, page.getByText("na fila", { exact: true }), page.getByText("concluída 0", { exact: true }));
+
+  await expect(page.getByText("concluída 1", { exact: true })).toBeVisible();
+  await expect(page.getByText("a fazer 0", { exact: true })).toBeVisible();
+  await expect(page.locator("canvas")).toHaveCount(1);
+});
+
+test("kanban: move tarefa entre colunas (todo → em andamento)", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "na fila");
+
+  await page.getByRole("button", { name: "kanban" }).click();
+
+  await drag(page, page.getByText("na fila", { exact: true }), page.getByText("em andamento 0", { exact: true }));
+
+  await expect(page.getByText("em andamento 1", { exact: true })).toBeVisible();
+  await expect(page.getByText("a fazer 0", { exact: true })).toBeVisible();
+  await expect(page.getByText("na fila", { exact: true })).toBeVisible();
+});

--- a/e2e/export-import.spec.ts
+++ b/e2e/export-import.spec.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from "node:fs";
+import { expect, test, type Page } from "@playwright/test";
+
+async function createProject(page: Page, title: string) {
+  const empty = page.getByRole("button", { name: "+ criar primeiro projeto" });
+  if (await empty.isVisible()) {
+    await empty.click();
+  } else {
+    await page.getByRole("button", { name: "+ projeto" }).click();
+  }
+  await page.getByLabel("título").fill(title);
+  await page.getByRole("button", { name: "criar" }).click();
+}
+
+async function addTask(page: Page, text: string) {
+  await page.getByLabel("nova tarefa").first().fill(text);
+  await page.getByLabel("nova tarefa").first().press("Enter");
+}
+
+const SEED = {
+  projetos: [
+    {
+      id: "p1",
+      title: "alpha",
+      blocked: false,
+      sections: [
+        {
+          id: "s1",
+          title: "geral",
+          notes: "",
+          collapsed: false,
+          tasks: [{ id: "t1", text: "tarefa do alpha", status: "todo", note: "", blocked: false, prio: 3, due: "", doneAt: null }],
+        },
+      ],
+    },
+    {
+      id: "p2",
+      title: "beta",
+      blocked: false,
+      sections: [
+        {
+          id: "s2",
+          title: "backlog",
+          notes: "",
+          collapsed: false,
+          tasks: [{ id: "t2", text: "tarefa do beta", status: "doing", note: "", blocked: false, prio: 2, due: "", doneAt: null }],
+        },
+      ],
+    },
+  ],
+};
+
+test("exporta JSON válido com o estado atual", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "alpha");
+  await addTask(page, "tarefa do alpha");
+
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByRole("button", { name: "↓exportar" }).click();
+  const download = await downloadPromise;
+  const path = await download.path();
+  expect(path).toBeTruthy();
+  const data = JSON.parse(readFileSync(path!, "utf8"));
+  expect(data.projetos).toHaveLength(1);
+  expect(data.projetos[0].title).toBe("alpha");
+  expect(data.projetos[0].sections[0].tasks[0].text).toBe("tarefa do alpha");
+});
+
+test("importa backup e restaura o estado", async ({ page }) => {
+  await page.goto("/");
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "backup.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(SEED)),
+  });
+
+  await expect(page.getByText("importado: 2 projeto(s)")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "alpha" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "beta" })).toBeVisible();
+  await expect(page.getByText("tarefa do beta", { exact: false })).toBeVisible();
+});
+
+test("import de arquivo corrompido mostra erro e não muda nada", async ({ page }) => {
+  await page.goto("/");
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "quebrado.json",
+    mimeType: "application/json",
+    buffer: Buffer.from("{isso não é json"),
+  });
+
+  await expect(page.getByText("arquivo em formato inválido")).toBeVisible();
+  await expect(page.getByText("nenhum projeto na fila.")).toBeVisible();
+});
+
+test("migra localStorage v1 → v2 no carregamento", async ({ page }) => {
+  const v1 = {
+    state: {
+      projetos: [
+        {
+          id: "p1",
+          title: "legado",
+          blocked: false,
+          sections: [
+            {
+              id: "s1",
+              title: "geral",
+              notes: "",
+              collapsed: false,
+              tasks: [{ id: "t1", text: "tarefa antiga", status: "todo" }],
+            },
+          ],
+        },
+      ],
+    },
+    version: 1,
+  };
+  await page.addInitScript((state) => {
+    localStorage.setItem("opsboard.v1", JSON.stringify(state));
+  }, v1);
+
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "legado" })).toBeVisible();
+  await expect(page.getByText("tarefa antiga", { exact: false })).toBeVisible();
+
+  const stored = await page.evaluate(() => JSON.parse(localStorage.getItem("opsboard.v1") ?? "{}"));
+  expect(stored.version).toBe(2);
+  expect(stored.state.projetos[0].sections[0].tasks[0]).toMatchObject({ text: "tarefa antiga", prio: 3, doneAt: null });
+});


### PR DESCRIPTION
## O que mudou

### `e2e/dnd.spec.ts` — arrasto nos 4 destinos
- **Reordenar** dentro da seção (task → task)
- **Mover entre seções** (task → seção) com validação dos contadores `0/0` e `0/2`
- **Kanban: mudar status** arrastando para a coluna concluída — dispara confete (assert de canvas do canvas-confetti)
- **Kanban: entre colunas** (todo → em andamento)
- Drag manual com `page.mouse` (down → move >6px para ativar o `PointerSensor` → move até o alvo → up), necessário para o `activationConstraint: distance 6`

### `e2e/export-import.spec.ts` — backup e persistência
- **Export**: `↓exportar` gera download; JSON validado (projetos/tarefas)
- **Import** válido restaura estado (toast `importado: 2 projeto(s)`)
- **Import corrompido** → toast `arquivo em formato inválido`, nada muda
- **Migração v1 → v2**: localStorage injetado com `{ state, version: 1 }` antes do load; app migra (defaults `prio: 3`, `doneAt: null`) e reescreve como `version: 2`

> Descoberta durante o trabalho: o zustand v5 só chama `migrate` quando `typeof version === "number"` — storage sem `version` é ignorado silenciosamente. O formato legado real (persist v4/v5) sempre grava `{ state, version }`, então o teste usa esse formato.

## Verificação

- 160 testes vitest verdes
- 19 e2e verdes (Playwright, chromium) — 8 novos
- typecheck 0 erros, lint 0 erros
- CI (job `check`) roda tudo neste PR

Close #15