### PR TITLE
Fase 5.1 — headers de segurança + CSP estrito

### DIFF
--- a/e2e/security.spec.ts
+++ b/e2e/security.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+
+test("responde com headers de segurança", async ({ request }) => {
+  const res = await request.get("/");
+  expect(res.ok()).toBe(true);
+  const h = res.headers();
+
+  expect(h["content-security-policy"]).toContain("default-src 'self'");
+  expect(h["content-security-policy"]).toContain("frame-ancestors 'none'");
+  expect(h["content-security-policy"]).toContain("object-src 'none'");
+  expect(h["content-security-policy"]).not.toContain("fonts.googleapis.com");
+  expect(h["x-content-type-options"]).toBe("nosniff");
+  expect(h["x-frame-options"]).toBe("DENY");
+  expect(h["referrer-policy"]).toBe("no-referrer");
+  expect(h["permissions-policy"]).toContain("geolocation=()");
+  expect(h["permissions-policy"]).toContain("microphone=()");
+});
+
+test("nenhuma violação de CSP no fluxo principal", async ({ page }) => {
+  const violations: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error") violations.push(m.text());
+  });
+  page.on("pageerror", (e) => violations.push(String(e)));
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "+ criar primeiro projeto" }).click();
+  await page.getByLabel("título").fill("app");
+  await page.getByRole("button", { name: "criar" }).click();
+  await page.getByLabel("nova tarefa").first().fill("tarefa segura");
+  await page.getByLabel("nova tarefa").first().press("Enter");
+  await page.getByRole("button", { name: "kanban" }).click();
+  await page.waitForTimeout(300);
+
+  expect(violations).toEqual([]);
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,33 @@
 import type { NextConfig } from "next";
 
+const CSP = [
+  "default-src 'self'",
+  // 'unsafe-inline' em script: único script inline do app é o ThemeScript
+  // (antiflash de tema do next-themes); sem ele há FOUC no primeiro load.
+  "script-src 'self' 'unsafe-inline'",
+  // 'unsafe-inline' em style: transform inline do dnd-kit (drag & drop)
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "connect-src 'self'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+].join("; ");
+
+const securityHeaders = [
+  { key: "Content-Security-Policy", value: CSP },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Referrer-Policy", value: "no-referrer" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=(), payment=(), usb=()" },
+];
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [{ source: "/:path*", headers: securityHeaders }];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## O que mudou

### `next.config.ts` — headers de segurança em todas as rotas
- **CSP estrito**: `default-src 'self'`, `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`, `frame-ancestors 'none'`, `img-src 'self' data:`, `font-src 'self'` (fontes self-hosted do `next/font`), `connect-src 'self'` — **nenhuma origem externa**
- `script-src 'self' 'unsafe-inline'` — exceção única e documentada: o ThemeScript inline do next-themes (antiflash de tema); sem ele há FOUC no primeiro load
- `style-src 'self' 'unsafe-inline'` — exceção necessária: transform inline do dnd-kit no drag & drop
- **X-Content-Type-Options: nosniff** · **X-Frame-Options: DENY** · **Referrer-Policy: no-referrer** · **Permissions-Policy** negando camera/mic/geolocation/payment/usb

### `e2e/security.spec.ts`
- Assert de todos os headers na resposta de `/` (CSP, nosniff, DENY, no-referrer, permissions)
- Assert de **zero erros de console/violations de CSP** no fluxo principal (criar projeto → tarefa → kanban)

## Verificação

- 21 e2e verdes (2 novos), 160 vitest verdes, typecheck/lint/build OK
- `next build` com `next/font/google` self-hosted — sem request externo em runtime
- Deploy na Vercel valida os headers em produção (preview do PR)

Close #16