### PR TITLE
Fase 5.4 — hardening do import JSON + validação de schema

### DIFF
--- a/e2e/export-import.spec.ts
+++ b/e2e/export-import.spec.ts
@@ -92,6 +92,49 @@ test("import de arquivo corrompido mostra erro e não muda nada", async ({ page 
   await expect(page.getByText("nenhum projeto na fila.")).toBeVisible();
 });
 
+test("import de JSON válido com estrutura inválida mostra erro claro", async ({ page }) => {
+  await page.goto("/");
+  const injetado = {
+    projetos: [
+      {
+        id: "p1",
+        title: "alpha",
+        blocked: false,
+        sections: [
+          {
+            id: "s1",
+            title: "geral",
+            notes: "",
+            collapsed: false,
+            tasks: [{ id: "t1", text: "x", status: "todo", prio: "urgente", note: "", blocked: false, due: "", doneAt: null }],
+          },
+        ],
+      },
+    ],
+  };
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "injetado.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(injetado)),
+  });
+
+  await expect(page.getByText("dados inválidos: estrutura de projeto, seção ou tarefa incorreta")).toBeVisible();
+  await expect(page.getByText("nenhum projeto na fila.")).toBeVisible();
+});
+
+test("import de arquivo gigante é rejeitado sem quebrar o estado", async ({ page }) => {
+  await page.goto("/");
+  const gigante = JSON.stringify({ projetos: [] }).padEnd(2 * 1024 * 1024 + 1, " ");
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "gigante.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(gigante),
+  });
+
+  await expect(page.getByText("arquivo muito grande (máx. 2 MB)")).toBeVisible();
+  await expect(page.getByText("nenhum projeto na fila.")).toBeVisible();
+});
+
 test("migra localStorage v1 → v2 no carregamento", async ({ page }) => {
   const v1 = {
     state: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ import { useTheme } from "next-themes";
 import { celebrate } from "@/lib/celebrate";
 import { exportJson, parseImport } from "@/lib/io";
 import { blockedCount, countByStatus } from "@/lib/selectors";
-import { useBoard } from "@/lib/store";
+import { useBoard, setStorageErrorHandler } from "@/lib/store";
 
 export default function Home() {
   const projetos = useBoard((s) => s.projetos);
@@ -42,11 +42,16 @@ export default function Home() {
   const fileRef = useRef<HTMLInputElement | null>(null);
   const prevDone = useRef(0);
 
-  const showToast = (msg: string) => {
+  const showToast = useCallback((msg: string) => {
     setToast(msg);
     if (toastTimer.current) clearTimeout(toastTimer.current);
     toastTimer.current = setTimeout(() => setToast(null), 1600);
-  };
+  }, []);
+
+  useEffect(() => {
+    setStorageErrorHandler(() => showToast("armazenamento cheio: alterações podem não ser salvas"));
+    return () => setStorageErrorHandler(null);
+  }, [showToast]);
 
   const doneCount = countByStatus(projetos).done;
   useEffect(() => {

--- a/src/lib/io.test.ts
+++ b/src/lib/io.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { exportJson, parseImport } from "./io";
+import { exportJson, MAX_BYTES, MAX_PROJECTS, MAX_TASKS, parseImport } from "./io";
 import type { Project } from "./types";
 
 const projeto = (): Project => ({
@@ -78,5 +78,59 @@ describe("parseImport", () => {
 
   it("formata JSON com indentação", () => {
     expect(exportJson([projeto()])).toContain("\n  ");
+  });
+
+  it("rejeita prio fora de 1..3", () => {
+    for (const prio of [0, 4, 1.5]) {
+      const raw = JSON.parse(exportJson([projeto()]));
+      raw.projetos[0].sections[0].tasks[0].prio = prio;
+      expect(() => parseImport(JSON.stringify(raw))).toThrow(/inválido/i);
+    }
+  });
+
+  it("rejeita tarefa sem campos obrigatórios (note/doneAt)", () => {
+    const raw = JSON.parse(exportJson([projeto()]));
+    delete raw.projetos[0].sections[0].tasks[0].doneAt;
+    expect(() => parseImport(JSON.stringify(raw))).toThrow(/inválido/i);
+  });
+
+  it("rejeita IDs duplicados (projeto, seção, tarefa)", () => {
+    const raw = JSON.parse(exportJson([projeto()]));
+    raw.projetos[0].sections.push(raw.projetos[0].sections[0]);
+    expect(() => parseImport(JSON.stringify(raw))).toThrow(/duplicado/i);
+
+    const raw2 = JSON.parse(exportJson([projeto(), projeto()]));
+    expect(() => parseImport(JSON.stringify(raw2))).toThrow(/duplicado/i);
+
+    const raw3 = JSON.parse(exportJson([projeto()]));
+    raw3.projetos[0].sections[0].tasks.push(raw3.projetos[0].sections[0].tasks[0]);
+    expect(() => parseImport(JSON.stringify(raw3))).toThrow(/duplicado/i);
+  });
+
+  it("rejeita arquivo acima de 2 MB", () => {
+    const big = JSON.stringify({ projetos: [] }).padEnd(MAX_BYTES + 1, " ");
+    expect(() => parseImport(big)).toThrow(/muito grande/i);
+  });
+
+  it("rejeita número de nós acima dos limites", () => {
+    const manyTasks = JSON.parse(exportJson([projeto()]));
+    manyTasks.projetos[0].sections[0].tasks = Array.from({ length: MAX_TASKS + 1 }, (_, i) => ({
+      ...manyTasks.projetos[0].sections[0].tasks[0],
+      id: `t${i}`,
+    }));
+    expect(() => parseImport(JSON.stringify(manyTasks))).toThrow(/limite/i);
+
+    const manyProjects = Array.from({ length: MAX_PROJECTS + 1 }, (_, i) => {
+      const p = JSON.parse(exportJson([projeto()])).projetos[0];
+      return { ...p, id: `p${i}` };
+    });
+    expect(() => parseImport(JSON.stringify(manyProjects))).toThrow(/limite/i);
+  });
+
+  it("exporta apenas projetos (sem outros campos de estado)", () => {
+    const out = exportJson([projeto()]);
+    expect(out).toContain('"projetos"');
+    expect(out).not.toContain('"filtros"');
+    expect(out).not.toContain("version");
   });
 });

--- a/src/lib/io.ts
+++ b/src/lib/io.ts
@@ -1,34 +1,52 @@
 import type { Project, Status } from "@/lib/types";
 
+export const MAX_BYTES = 2 * 1024 * 1024;
+export const MAX_PROJECTS = 100;
+export const MAX_SECTIONS = 500;
+export const MAX_TASKS = 5000;
+
 const STATUSES: Status[] = ["todo", "doing", "waiting", "done"];
-const isTask = (t: unknown): t is Project["sections"][number]["tasks"][number] => {
+
+const isNullableString = (v: unknown) => v === null || typeof v === "string";
+
+const isTask = (t: unknown): boolean => {
   if (!t || typeof t !== "object") return false;
   const o = t as Record<string, unknown>;
   return (
     typeof o.id === "string" &&
+    o.id.length > 0 &&
     typeof o.text === "string" &&
     STATUSES.includes(o.status as Status) &&
-    typeof o.prio === "number"
+    Number.isInteger(o.prio) &&
+    (o.prio as number) >= 1 &&
+    (o.prio as number) <= 3 &&
+    isNullableString(o.note) &&
+    isNullableString(o.due) &&
+    isNullableString(o.doneAt) &&
+    typeof o.blocked === "boolean"
   );
 };
 
-const isSection = (s: unknown): s is Project["sections"][number] => {
+const isSection = (s: unknown): boolean => {
   if (!s || typeof s !== "object") return false;
   const o = s as Record<string, unknown>;
   return (
     typeof o.id === "string" &&
+    o.id.length > 0 &&
     typeof o.title === "string" &&
     typeof o.collapsed === "boolean" &&
+    typeof o.notes === "string" &&
     Array.isArray(o.tasks) &&
     o.tasks.every(isTask)
   );
 };
 
-const isProject = (p: unknown): p is Project => {
+const isProject = (p: unknown): boolean => {
   if (!p || typeof p !== "object") return false;
   const o = p as Record<string, unknown>;
   return (
     typeof o.id === "string" &&
+    o.id.length > 0 &&
     typeof o.title === "string" &&
     typeof o.blocked === "boolean" &&
     Array.isArray(o.sections) &&
@@ -41,18 +59,54 @@ export function exportJson(projetos: Project[]): string {
 }
 
 export function parseImport(raw: string): Project[] {
+  if (raw.length > MAX_BYTES) {
+    throw new Error("arquivo muito grande (máx. 2 MB)");
+  }
+
   let data: unknown;
   try {
     data = JSON.parse(raw) as unknown;
   } catch {
     throw new Error("arquivo em formato inválido");
   }
+
   const projetos = Array.isArray(data)
     ? data
     : data && typeof data === "object" && Array.isArray((data as { projetos?: unknown }).projetos)
       ? (data as { projetos: unknown[] }).projetos
       : null;
   if (!projetos) throw new Error("arquivo em formato inválido");
-  if (!projetos.every(isProject)) throw new Error("arquivo em formato inválido");
-  return projetos as Project[];
+  if (projetos.length > MAX_PROJECTS) {
+    throw new Error(`limite excedido: máx. ${MAX_PROJECTS} projetos`);
+  }
+  if (!projetos.every(isProject)) {
+    throw new Error("dados inválidos: estrutura de projeto, seção ou tarefa incorreta");
+  }
+
+  const list = projetos as Project[];
+  const ids = new Set<string>();
+  let sections = 0;
+  let tasks = 0;
+  for (const p of list) {
+    if (ids.has(p.id)) throw new Error("dados inválidos: IDs duplicados");
+    ids.add(p.id);
+    for (const s of p.sections) {
+      if (ids.has(s.id)) throw new Error("dados inválidos: IDs duplicados");
+      ids.add(s.id);
+      sections++;
+      for (const t of s.tasks) {
+        if (ids.has(t.id)) throw new Error("dados inválidos: IDs duplicados");
+        ids.add(t.id);
+        tasks++;
+      }
+    }
+  }
+  if (sections > MAX_SECTIONS) {
+    throw new Error(`limite excedido: máx. ${MAX_SECTIONS} seções`);
+  }
+  if (tasks > MAX_TASKS) {
+    throw new Error(`limite excedido: máx. ${MAX_TASKS} tarefas`);
+  }
+
+  return list;
 }

--- a/src/lib/store.test.ts
+++ b/src/lib/store.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { createBoardStore } from "./store";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createBoardStore, setStorageErrorHandler } from "./store";
 import type { Project } from "./types";
 
 const seedProjeto = (): Project => ({
@@ -216,5 +216,22 @@ describe("persistência", () => {
     localStorage.setItem("opsboard.v1", JSON.stringify({ state: { foo: 1 }, version: 1 }));
     const s = createBoardStore();
     expect(s.getState().projetos).toEqual([]);
+  });
+});
+describe("storage error handler (quota)", () => {
+  it("notifica quando setItem falha (quota excedida)", () => {
+    const store = createBoardStore();
+    const handler = vi.fn();
+    setStorageErrorHandler(handler);
+    const spy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("quota", "QuotaExceededError");
+    });
+    try {
+      store.setState({ projetos: [seedProjeto()] });
+    } finally {
+      spy.mockRestore();
+      setStorageErrorHandler(null);
+    }
+    expect(handler).toHaveBeenCalled();
   });
 });

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -4,6 +4,24 @@ import { migrateLegacy, normalizeState, SCHEMA_VERSION } from "./migrate";
 import type { Prio, Project, Section, Status, TaskPatch } from "./types";
 import { uid } from "./uid";
 
+let storageErrorHandler: (() => void) | null = null;
+
+export function setStorageErrorHandler(fn: (() => void) | null) {
+  storageErrorHandler = fn;
+}
+
+const safeLocalStorage = {
+  getItem: (name: string) => localStorage.getItem(name),
+  setItem: (name: string, value: string) => {
+    try {
+      localStorage.setItem(name, value);
+    } catch {
+      storageErrorHandler?.();
+    }
+  },
+  removeItem: (name: string) => localStorage.removeItem(name),
+};
+
 interface BoardStore {
   projetos: Project[];
   addProject: (title: string) => void;
@@ -292,7 +310,7 @@ export function createBoardStore(initial: Project[] = []) {
       {
         name: "opsboard.v1",
         version: SCHEMA_VERSION,
-        storage: createJSONStorage(() => localStorage),
+        storage: createJSONStorage(() => safeLocalStorage),
         migrate: (persisted, version) => {
           if (version < SCHEMA_VERSION) {
             const legacy = migrateLegacy(persisted);


### PR DESCRIPTION
## O que mudou

### Hardening do import (`src/lib/io.ts`)
- **Limites**: arquivo máx. 2 MB; 100 projetos / 500 seções / 5000 tarefas — com mensagens claras (`arquivo muito grande (máx. 2 MB)`, `limite excedido: máx. N ...`)
- **Schema profundo**: todos os campos tipados (id/text/title strings não vazias, `note`/`due`/`doneAt` null|string, `blocked`/`collapsed` booleans, `status` ∈ {todo,doing,waiting,done}, `prio` inteiro 1–3)
- **IDs únicos** em projeto/seção/tarefa → `dados inválidos: IDs duplicados`
- Erro de estrutura agora é específico: `dados inválidos: estrutura de projeto, seção ou tarefa incorreta` (antes tudo virava "formato inválido")
- Erros sempre chegam ao toast sem tocar o estado atual (import falha → nada muda)

### Quota de localStorage (`src/lib/store.ts` + `page.tsx`)
- Storage wrapper `safeLocalStorage` com `setStorageErrorHandler` — `setItem` falhou (quota excedida) → callback dispara toast `armazenamento cheio: alterações podem não ser salvas`
- Sem perda silenciosa: o toast avisa o usuário imediatamente

### Export
- Confirmado por teste: exporta apenas `{ projetos }` — sem filtros/versão/outros campos de estado

## Testes

- **Unit** (+8): prio fora de 1..3, campos obrigatórios faltando, IDs duplicados (3 níveis), arquivo >2 MB, nós acima do limite, export sem vazamento de estado, handler de quota (spy em `Storage.prototype.setItem` lançando `QuotaExceededError`)
- **E2E** (+2): import com estrutura injetada (`prio: "urgente"`) → erro claro + estado intacto; arquivo 2 MB+ → `arquivo muito grande` + estado intacto
- 169 vitest + 24 e2e verdes, typecheck/build OK

Close #19