### PR TITLE
Fase 6.1 — transparência: aviso + política de privacidade (LGPD)

### DIFF
--- a/e2e/privacy.spec.ts
+++ b/e2e/privacy.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+test("aviso de privacidade aparece na primeira visita e some ao aceitar", async ({ page }) => {
+  await page.goto("/");
+  const dialog = page.getByRole("dialog", { name: "aviso de privacidade" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("Seus dados, só no seu navegador")).toBeVisible();
+
+  await dialog.getByRole("button", { name: "entendi" }).click();
+  await expect(dialog).toBeHidden();
+
+  await page.reload();
+  await expect(dialog).toHaveCount(0);
+});
+
+test("aviso não reaparece quando já aceito (localStorage persistido)", async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem("opsboard.notice-v1", "1"));
+  await page.goto("/");
+  await expect(page.getByRole("dialog", { name: "aviso de privacidade" })).toHaveCount(0);
+});
+
+test("política de privacidade acessível em 1 clique pelo topbar", async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem("opsboard.notice-v1", "1"));
+  await page.goto("/");
+
+  await page.getByRole("link", { name: "privacidade" }).click();
+
+  await expect(page).toHaveURL(/\/privacidade/);
+  await expect(page.getByRole("heading", { name: "Política de privacidade" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Base legal" })).toBeVisible();
+  await expect(page.getByText("localStorage", { exact: false })).toBeVisible();
+  await expect(page.getByText("direitos do titular (LGPD, art. 18)", { exact: false })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Como apagar todos os dados" })).toBeVisible();
+});
+
+test("aviso oferece link direto para a política", async ({ page }) => {
+  await page.goto("/");
+  const dialog = page.getByRole("dialog", { name: "aviso de privacidade" });
+  await dialog.getByRole("link", { name: "política completa" }).click();
+  await expect(page).toHaveURL(/\/privacidade/);
+  await expect(page.getByRole("heading", { name: "Política de privacidade" })).toBeVisible();
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Board } from "@/components/client/board/Board";
 import { FilterChips } from "@/components/client/FilterChips";
 import { Modal } from "@/components/client/Modal";
+import { PrivacyNotice } from "@/components/client/PrivacyNotice";
 import { Stats } from "@/components/client/Stats";
 import { Topbar } from "@/components/client/Topbar";
 import { useFilters } from "@/hooks/useFilters";
@@ -181,6 +182,8 @@ export default function Home() {
           onCancel={() => setNewProjectOpen(false)}
         />
       )}
+
+      <PrivacyNotice />
 
       {toast && (
         <div className="fixed bottom-5 left-1/2 -translate-x-1/2 z-50 bg-[var(--panel-3)] border border-zinc-600 text-[var(--text)] text-xs px-4 py-2 rounded-md shadow-lg">

--- a/src/app/privacidade/page.tsx
+++ b/src/app/privacidade/page.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacidade — OpsBoard",
+  description:
+    "Política de privacidade do OpsBoard: onde os dados ficam, base legal, direitos do titular e como apagar tudo.",
+};
+
+const SECTIONS = [
+  {
+    title: "1. Finalidade do tratamento",
+    body: "O OpsBoard é uma ferramenta de controle de tarefas pessoal. Os dados informados (títulos de projetos, tarefas, notas e prioridades) são usados exclusivamente para exibir e organizar o seu quadro no navegador. Não há coleta de dados para perfilamento, publicidade ou qualquer outro fim.",
+  },
+  {
+    title: "2. Onde os dados ficam",
+    body: "Todos os dados são armazenados exclusivamente no armazenamento local do seu navegador (localStorage), sob a chave opsboard.v1. Eles nunca são enviados a servidores, não saem do seu dispositivo e não são compartilhados com terceiros. O tema escolhido também é salvo localmente (opsboard.theme).",
+  },
+  {
+    title: "3. Base legal",
+    body: "Por não haver envio ou tratamento de dados pessoais por servidores de terceiros, o tratamento é local e técnico (Lei 13.709/2018 — LGPD, art. 7º, inciso II). O uso da ferramenta e o consentimento para esse tratamento são manifestados ao aceitar o aviso exibido no primeiro acesso.",
+  },
+  {
+    title: "4. Direitos do titular (LGPD, art. 18)",
+    body: "Como os dados estão apenas no seu navegador, você controla tudo diretamente: acesso (consulte o quadro), correção (edite projetos, seções e tarefas), portabilidade (use o botão exportar para baixar um backup JSON) e exclusão (apague projetos/tarefas na interface ou limpe os dados do site nas configurações do navegador).",
+  },
+  {
+    title: "5. Como apagar todos os dados",
+    body: "O botão exportar baixa um backup. Para apagar tudo: nas configurações do navegador, em 'Dados do site', remova os dados do domínio deste app — ou apague os projetos um a um no quadro.",
+  },
+  {
+    title: "6. Contato",
+    body: "Questões sobre esta política podem ser abertas no repositório público do projeto (github.com/lmaoclost/ops-board), seção Issues.",
+  },
+];
+
+export default function PrivacidadePage() {
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-10">
+      <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">Política de privacidade</h1>
+      <p className="mt-2 text-sm text-[var(--muted-text)]">
+        OpsBoard — controle de tarefas. Dados ficam apenas no seu navegador.
+      </p>
+      <div className="mt-8 space-y-6">
+        {SECTIONS.map((s) => (
+          <section key={s.title}>
+            <h2 className="text-base font-semibold text-[var(--text)]">{s.title}</h2>
+            <p className="mt-1.5 text-sm leading-relaxed text-[var(--muted-text)]">{s.body}</p>
+          </section>
+        ))}
+      </div>
+      <p className="mt-10 text-xs text-[var(--dimmer)]">
+        Atualizado em agosto de 2026.
+      </p>
+    </main>
+  );
+}

--- a/src/components/client/PrivacyNotice.tsx
+++ b/src/components/client/PrivacyNotice.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+const NOTICE_KEY = "opsboard.notice-v1";
+
+export function PrivacyNotice() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!localStorage.getItem(NOTICE_KEY)) setOpen(true);
+  }, []);
+
+  const dismiss = () => {
+    localStorage.setItem(NOTICE_KEY, "1");
+    setOpen(false);
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="aviso de privacidade"
+      className="fixed bottom-5 left-1/2 z-50 w-[min(92vw,26rem)] -translate-x-1/2 rounded-lg border border-[var(--line)] bg-[var(--panel)] p-4 shadow-xl"
+    >
+      <h2 className="text-sm font-bold tracking-wide text-[var(--text)]">Seus dados, só no seu navegador</h2>
+      <p className="mt-1.5 text-xs leading-relaxed text-[var(--muted-text)]">
+        O OpsBoard processa os seus dados localmente e os guarda apenas no armazenamento do seu navegador
+        (localStorage). Nada é enviado a servidores. Você pode exportar um backup a qualquer momento e apagar
+        tudo pelos controles do quadro. Veja a política completa na página de privacidade.
+      </p>
+      <div className="mt-3 flex items-center justify-end gap-2">
+        <Button type="button" variant="ghost" size="xs" render={<a href="/privacidade" />}>
+          política completa
+        </Button>
+        <Button type="button" variant="default" size="sm" onClick={dismiss}>
+          entendi
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/client/PrivacyNotice.tsx
+++ b/src/components/client/PrivacyNotice.tsx
@@ -9,6 +9,7 @@ export function PrivacyNotice() {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (!localStorage.getItem(NOTICE_KEY)) setOpen(true);
   }, []);
 

--- a/src/components/client/Topbar.tsx
+++ b/src/components/client/Topbar.tsx
@@ -104,6 +104,16 @@ export function Topbar({
             >
               ↑importar
             </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              render={<a href="/privacidade" />}
+              className="text-[var(--muted-text)] hover:text-[var(--text)]"
+              title="política de privacidade"
+            >
+              privacidade
+            </Button>
             <Button type="button" variant="default" size="sm" onClick={onNewProject}>
               <span className="mr-1">+</span>projeto
             </Button>


### PR DESCRIPTION
## O que mudou

### Aviso inicial (LGPD art. 6º — transparência)
- **`PrivacyNotice`**: card não-bloqueante no primeiro acesso — informa que os dados são processados localmente, ficam no `localStorage`, não saem do navegador, e que existe backup/exportação
- Dismiss persistido em `opsboard.notice-v1` — aparece uma única vez, sem fricção (não bloqueia o uso do app)
- Botão `política completa` leva direto à página

### Página `/privacidade` (LGPD art. 18)
- Finalidade do tratamento (sem coleta/perfilamento)
- Onde os dados ficam (localStorage `opsboard.v1`, nunca enviados)
- Base legal (LGPD art. 7º, II — tratamento local/técnico + consentimento pelo aviso)
- Direitos do titular: acesso, correção, portabilidade (exportar) e exclusão
- Como apagar todos os dados + contato (repo público)

### Topbar
- Link `privacidade` ao lado de importar — política acessível em 1 clique de qualquer tela

## Testes (e2e +4)
- Aviso aparece na 1ª visita; `entendi` → some e não reaparece após reload
- Aviso não reaparece com flag persistida
- Link do topbar → página de privacidade com todos os blocos (base legal, art. 18, apagar dados)
- Aviso oferece link direto para a política
- 28 e2e + 169 vitest verdes; typecheck/lint/build OK

Close #20