### PR TITLE
Fase 6.2 — direitos do titular: export completo e apagar dados

### DIFF
--- a/e2e/rights.spec.ts
+++ b/e2e/rights.spec.ts
@@ -1,0 +1,133 @@
+import { readFileSync } from "node:fs";
+import { expect, test, type Page } from "@playwright/test";
+
+const SEED = {
+  projetos: [
+    {
+      id: "p1",
+      title: "alpha",
+      blocked: false,
+      sections: [
+        {
+          id: "s1",
+          title: "geral",
+          notes: "notas do alpha",
+          collapsed: false,
+          tasks: [{ id: "t1", text: "tarefa do alpha", status: "todo", note: "", blocked: false, prio: 3, due: "", doneAt: null }],
+        },
+      ],
+    },
+    {
+      id: "p2",
+      title: "beta",
+      blocked: true,
+      sections: [
+        {
+          id: "s2",
+          title: "geral",
+          notes: "",
+          collapsed: false,
+          tasks: [{ id: "t2", text: "tarefa do beta", status: "done", note: "feito", blocked: false, prio: 1, due: "2026-08-20", doneAt: "2026-08-14T10:00:00.000Z" }],
+        },
+      ],
+    },
+  ],
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem("opsboard.notice-v1", "1"));
+});
+
+async function storedProjects(page: Page): Promise<unknown[]> {
+  return page.evaluate(() => {
+    const raw = localStorage.getItem("opsboard.v1");
+    if (!raw) return null;
+    return JSON.parse(raw).state.projetos;
+  });
+}
+
+test("apagar tudo exige confirmação e remove 100% dos dados do localStorage", async ({ page }) => {
+  await page.goto("/");
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "backup.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(SEED)),
+  });
+  await expect(page.getByRole("heading", { name: "alpha" })).toBeVisible();
+
+  await page.getByRole("button", { name: "apagar todos os dados" }).click();
+  const dialog = page.getByRole("dialog", { name: "apagar todos os dados" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("2 projeto(s)")).toBeVisible();
+
+  await dialog.getByRole("button", { name: "cancelar" }).click();
+  await expect(page.getByRole("heading", { name: "alpha" })).toBeVisible();
+  expect(await storedProjects(page)).toHaveLength(2);
+
+  await page.getByRole("button", { name: "apagar todos os dados" }).click();
+  await page.getByRole("dialog", { name: "apagar todos os dados" }).getByRole("button", { name: "apagar tudo" }).click();
+
+  await expect(page.getByText("todos os dados apagados")).toBeVisible();
+  await expect(page.getByText("nenhum projeto na fila.")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "alpha" })).toHaveCount(0);
+  expect(await storedProjects(page)).toEqual([]);
+});
+
+test("apagar item individual não deixa resíduo no localStorage", async ({ page }) => {
+  await page.goto("/");
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "backup.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(SEED)),
+  });
+  await expect(page.getByRole("heading", { name: "alpha" })).toBeVisible();
+
+  page.once("dialog", (dialog) => void dialog.accept());
+  await page
+    .locator("section.rounded-lg")
+    .filter({ has: page.getByRole("heading", { name: "alpha" }) })
+    .getByRole("button", { name: "ações do projeto", exact: true })
+    .click();
+  await page.getByRole("menuitem", { name: "excluir projeto" }).click();
+
+  await expect(page.getByRole("heading", { name: "alpha" })).toHaveCount(0);
+  await expect(page.getByRole("heading", { name: "beta" })).toBeVisible();
+
+  const stored = (await storedProjects(page)) as Array<{ title: string }>;
+  expect(stored.map((p) => p.title)).toEqual(["beta"]);
+  expect(JSON.stringify(stored)).not.toContain("alpha");
+  expect(JSON.stringify(stored)).not.toContain("tarefa do alpha");
+});
+
+test("export contém 100% do estado e import restaura igual", async ({ page }) => {
+  await page.goto("/");
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "backup.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(SEED)),
+  });
+  await expect(page.getByRole("heading", { name: "alpha" })).toBeVisible();
+
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByRole("button", { name: "↓exportar" }).click();
+  const download = await downloadPromise;
+  const exported = JSON.parse(readFileSync((await download.path())!, "utf8"));
+
+  expect(exported.projetos).toEqual(SEED.projetos);
+
+  await page.getByRole("button", { name: "apagar todos os dados" }).click();
+  await page.getByRole("dialog", { name: "apagar todos os dados" }).getByRole("button", { name: "apagar tudo" }).click();
+  await expect(page.getByText("nenhum projeto na fila.")).toBeVisible();
+
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "backup.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(exported)),
+  });
+
+  await expect(page.getByText("importado: 2 projeto(s)")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "alpha" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "beta" })).toBeVisible();
+  await expect(page.getByText("notas do alpha", { exact: false })).toBeVisible();
+  expect(await storedProjects(page)).toEqual(SEED.projetos);
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,8 @@ import { celebrate } from "@/lib/celebrate";
 import { exportJson, parseImport } from "@/lib/io";
 import { blockedCount, countByStatus } from "@/lib/selectors";
 import { useBoard, setStorageErrorHandler } from "@/lib/store";
+import { Dialog, DialogClose, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 
 export default function Home() {
   const projetos = useBoard((s) => s.projetos);
@@ -33,6 +35,8 @@ export default function Home() {
   const toggleSection = useBoard((s) => s.toggleSection);
   const moveTask = useBoard((s) => s.moveTask);
   const importState = useBoard((s) => s.importState);
+  const reset = useBoard((s) => s.reset);
+  const [confirmClearOpen, setConfirmClearOpen] = useState(false);
   const { filters, setQuery, toggleStatus, togglePrioSort, toggleView, clear } = useFilters();
   const { resolvedTheme, setTheme } = useTheme();
   const isDark = resolvedTheme !== "light";
@@ -168,6 +172,59 @@ export default function Home() {
           }}
         />
       </main>
+
+      <footer className="mx-auto max-w-5xl px-4 pb-8 text-center">
+        <button
+          type="button"
+          onClick={() => setConfirmClearOpen(true)}
+          className="text-[11px] text-[var(--dimmer)] underline underline-offset-2 hover:text-red-400 cursor-pointer"
+          title="remove todos os projetos deste navegador"
+        >
+          apagar todos os dados
+        </button>
+      </footer>
+
+      {confirmClearOpen && (
+        <Dialog open onOpenChange={(o) => { if (!o) setConfirmClearOpen(false); }}>
+          <DialogContent
+            showCloseButton={false}
+            className="!sm:max-w-[380px] gap-0 rounded-lg border border-[var(--line-soft)] bg-[var(--panel-2)] p-0 text-[var(--text)] shadow-xl"
+          >
+            <div className="flex items-center justify-between border-b border-[var(--line)] px-4 py-3">
+              <DialogTitle className="text-[13px] font-bold text-[var(--text)]">apagar todos os dados</DialogTitle>
+              <DialogClose
+                render={
+                  <Button type="button" variant="ghost" size="icon-xs" title="fechar" aria-label="fechar">
+                    ×
+                  </Button>
+                }
+              />
+            </div>
+            <div className="px-4 py-4 text-xs leading-relaxed text-[var(--muted-text)]">
+              Isso remove {projetos.length} projeto(s) deste navegador. Considere exportar um backup antes.
+              Esta ação não pode ser desfeita.
+            </div>
+            <div className="flex justify-end gap-2 px-4 pb-4">
+              <Button type="button" variant="ghost" size="xs" onClick={() => setConfirmClearOpen(false)}>
+                cancelar
+              </Button>
+              <Button
+                type="button"
+                variant="default"
+                size="sm"
+                className="bg-red-500 hover:bg-red-600"
+                onClick={() => {
+                  reset();
+                  setConfirmClearOpen(false);
+                  showToast("todos os dados apagados");
+                }}
+              >
+                apagar tudo
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
 
       {newProjectOpen && (
         <Modal

--- a/src/app/privacidade/page.tsx
+++ b/src/app/privacidade/page.tsx
@@ -25,7 +25,7 @@ const SECTIONS = [
   },
   {
     title: "5. Como apagar todos os dados",
-    body: "O botão exportar baixa um backup. Para apagar tudo: nas configurações do navegador, em 'Dados do site', remova os dados do domínio deste app — ou apague os projetos um a um no quadro.",
+    body: "No rodapé do quadro há o botão 'apagar todos os dados' — ele pede confirmação explícita e remove todos os projetos do navegador. Para apagar um item específico, use os controles de exclusão do próprio projeto/seção/tarefa. O botão exportar baixa um backup antes de qualquer exclusão. Também é possível remover os dados nas configurações do navegador, em 'Dados do site'.",
   },
   {
     title: "6. Contato",

--- a/src/lib/io.test.ts
+++ b/src/lib/io.test.ts
@@ -80,6 +80,12 @@ describe("parseImport", () => {
     expect(exportJson([projeto()])).toContain("\n  ");
   });
 
+  it("round-trip export → import restaura 100% do estado", () => {
+    const original = [projeto()];
+    const restored = parseImport(exportJson(original));
+    expect(restored).toEqual(original);
+  });
+
   it("rejeita prio fora de 1..3", () => {
     for (const prio of [0, 4, 1.5]) {
       const raw = JSON.parse(exportJson([projeto()]));


### PR DESCRIPTION
## O que mudou

### Apagar tudo com confirmação explícita (LGPD art. 18, II)
- Botão `apagar todos os dados` no rodapé do quadro
- Dialog de confirmação mostra a quantidade de projetos afetados, avisa sobre backup e que a ação é irreversível
- `cancelar` preserva tudo; `apagar tudo` chama o `reset` do store → `localStorage.opsboard.v1` fica com `projetos: []` (sem resíduo de dados)
- Toast `todos os dados apagados` confirma a ação

### Export/import 100% (art. 18, III — portabilidade)
- Teste unit round-trip: `exportJson → parseImport` restaura estado idêntico (igualdade profunda)
- E2E: export contém todos os campos (notas, prio, due, doneAt, blocked...), apagar tudo, re-importar → estado 100% restaurado e idêntico ao original no localStorage

### Apagar item individual
- E2E novo: excluir projeto com `confirm` → board e localStorage sem nenhum resíduo (título e tarefas do projeto excluído não aparecem na chave `opsboard.v1`)

### Política de privacidade
- Seção "Como apagar todos os dados" documenta o botão do rodapé, exclusão por item e o caminho do navegador

## Testes

- e2e +3 (`e2e/rights.spec.ts`), unit +1 (round-trip)
- 31 e2e + 170 vitest verdes, typecheck/lint/build OK

Close #21