### PR TITLE
chore: dependabot ignora majors de eslint/typescript

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,13 @@ updates:
         patterns:
           - "next"
           - "eslint-config-next"
+    ignore:
+      # eslint-plugin-react ainda não suporta ESLint 10 (quebra o lint)
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      # typescript-eslint ainda não suporta TypeScript 7 (quebra o lint)
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
chore: dependabot ignora majors de eslint e typescript

- `eslint` major: eslint-plugin-react ainda nao suporta ESLint 10 (CI quebrou com react/display-name)
- `typescript` major: typescript-eslint nao suporta TS 7 (CI quebrou no lint)
- ambos fechados com comentario (#46, #48); ignore evita que o Dependabot reabra
