### PR TITLE
perf: derivadas em uma passada, preload /privacidade, toSorted

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Board } from "@/components/client/board/Board";
 import { FilterChips } from "@/components/client/FilterChips";
 import { Modal } from "@/components/client/Modal";
@@ -12,7 +12,7 @@ import { useShortcuts } from "@/hooks/useShortcuts";
 import { useTheme } from "next-themes";
 import { celebrate } from "@/lib/celebrate";
 import { exportJson, parseImport } from "@/lib/io";
-import { blockedCount, countByStatus } from "@/lib/selectors";
+import { deriveStats } from "@/lib/selectors";
 import { useBoard, setStorageErrorHandler } from "@/lib/store";
 import { Dialog, DialogClose, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -58,11 +58,11 @@ export default function Home() {
     return () => setStorageErrorHandler(null);
   }, [showToast]);
 
-  const doneCount = countByStatus(projetos).done;
+  const stats = useMemo(() => deriveStats(projetos), [projetos]);
   useEffect(() => {
-    if (doneCount > prevDone.current) celebrate();
-    prevDone.current = doneCount;
-  }, [doneCount]);
+    if (stats.done > prevDone.current) celebrate();
+    prevDone.current = stats.done;
+  }, [stats.done]);
 
   const handleExport = useCallback(() => {
     const blob = new Blob([exportJson(projetos)], { type: "application/json" });
@@ -103,7 +103,7 @@ export default function Home() {
     { isModalOpen: () => newProjectOpen },
   );
 
-  const counts = countByStatus(projetos);
+  const counts = stats.byStatus;
 
   return (
     <div className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
@@ -134,7 +134,7 @@ export default function Home() {
       <div className="mx-auto max-w-5xl px-4 pb-2">
         <FilterChips
           counts={counts}
-          blockedCount={blockedCount(projetos)}
+          blockedCount={stats.blocked}
           active={filters.status}
           filtering={!!filters.query || !!filters.status}
           onToggleStatus={toggleStatus}
@@ -142,7 +142,7 @@ export default function Home() {
         />
       </div>
       <div className="mx-auto max-w-5xl px-4 pb-2">
-        <Stats projetos={projetos} filters={filters} onTogglePrioSort={togglePrioSort} />
+        <Stats stats={stats} filters={filters} onTogglePrioSort={togglePrioSort} />
       </div>
 
       <main className="mx-auto max-w-5xl px-4 py-6">

--- a/src/components/client/PrivacyNotice.tsx
+++ b/src/components/client/PrivacyNotice.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
 const NOTICE_KEY = "opsboard.notice-v1";
@@ -33,7 +34,7 @@ export function PrivacyNotice() {
         tudo pelos controles do quadro. Veja a política completa na página de privacidade.
       </p>
       <div className="mt-3 flex items-center justify-end gap-2">
-        <Button type="button" variant="ghost" size="xs" render={<a href="/privacidade" />}>
+        <Button type="button" variant="ghost" size="xs" render={<Link href="/privacidade" />}>
           política completa
         </Button>
         <Button type="button" variant="default" size="sm" onClick={dismiss}>

--- a/src/components/client/Stats.test.tsx
+++ b/src/components/client/Stats.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { Stats } from "../../components/client/Stats";
 import { defaultFilters, type Filters } from "../../lib/filter";
 import { todayISO } from "../../lib/date";
+import { deriveStats, type BoardStats } from "../../lib/selectors";
 import type { Project } from "../../lib/types";
 
 const projeto = (tasks: Project["sections"][number]["tasks"]): Project => ({
@@ -25,17 +26,19 @@ const task = (over: Partial<Project["sections"][number]["tasks"][number]> = {}):
   ...over,
 });
 
+const statsOf = (projetos: Project[]): BoardStats => deriveStats(projetos);
+
 describe("Stats", () => {
   it("mostra total, pendentes, concluídas com % e feitas hoje", () => {
     render(
       <Stats
-        projetos={[
+        stats={statsOf([
           projeto([
             task(),
             task({ id: "t2", status: "doing" }),
             task({ id: "t3", status: "done", doneAt: todayISO() + "T09:00:00.000Z" }),
           ]),
-        ]}
+        ])}
         filters={defaultFilters}
         onTogglePrioSort={() => {}}
       />,
@@ -49,7 +52,7 @@ describe("Stats", () => {
   it("casa 0% sem tarefas concluídas", () => {
     render(
       <Stats
-        projetos={[projeto([task()])]}
+        stats={statsOf([projeto([task()])])}
         filters={defaultFilters}
         onTogglePrioSort={() => {}}
       />,
@@ -60,7 +63,7 @@ describe("Stats", () => {
   it("toggle de prioridade invoca callback", async () => {
     const onTogglePrioSort = vi.fn();
     render(
-      <Stats projetos={[projeto([])]} filters={defaultFilters} onTogglePrioSort={onTogglePrioSort} />,
+      <Stats stats={statsOf([projeto([])])} filters={defaultFilters} onTogglePrioSort={onTogglePrioSort} />,
     );
     await userEvent.click(screen.getByRole("button", { name: "↕ prio" }));
     expect(onTogglePrioSort).toHaveBeenCalledTimes(1);
@@ -68,20 +71,20 @@ describe("Stats", () => {
 
   it("destaca dica de kanban quando em kanban", () => {
     const f: Filters = { ...defaultFilters, view: "kanban" };
-    render(<Stats projetos={[]} filters={f} onTogglePrioSort={() => {}} />);
+    render(<Stats stats={statsOf([])} filters={f} onTogglePrioSort={() => {}} />);
     expect(screen.getByText(/kanban: arraste/i)).toBeTruthy();
   });
 
   it("expõe contadores por data-testid estável", () => {
     render(
       <Stats
-        projetos={[
+        stats={statsOf([
           projeto([
             task(),
             task({ id: "t2", status: "doing" }),
             task({ id: "t3", status: "done", doneAt: todayISO() + "T09:00:00.000Z" }),
           ]),
-        ]}
+        ])}
         filters={defaultFilters}
         onTogglePrioSort={() => {}}
       />,

--- a/src/components/client/Stats.tsx
+++ b/src/components/client/Stats.tsx
@@ -1,25 +1,18 @@
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { countByStatus, doneTodayCount } from "@/lib/selectors";
-import type { Project } from "@/lib/types";
+import type { BoardStats } from "@/lib/selectors";
 import type { Filters } from "@/lib/filter";
-import { todayISO } from "@/lib/date";
 
 interface StatsProps {
-  projetos: Project[];
+  stats: BoardStats;
   filters: Filters;
   onTogglePrioSort: () => void;
 }
 
 const fmtPct = (done: number, total: number) => (total ? Math.round((done / total) * 100) : 0);
 
-export function Stats({ projetos, filters, onTogglePrioSort }: StatsProps) {
-  const counts = countByStatus(projetos);
-  const done = counts.done;
-  const total = Object.values(counts).reduce((a, b) => a + b, 0);
-  const pendentes = total - done;
-  const doneToday = doneTodayCount(projetos);
-
+export function Stats({ stats, filters, onTogglePrioSort }: StatsProps) {
+  const { done, total, pendentes, doneToday } = stats;
   const pct = fmtPct(done, total);
 
   const hint =

--- a/src/components/client/Topbar.tsx
+++ b/src/components/client/Topbar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
 import { useMounted } from "@/hooks/useMounted";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -108,7 +109,7 @@ export function Topbar({
               type="button"
               variant="ghost"
               size="xs"
-              render={<a href="/privacidade" />}
+              render={<Link href="/privacidade" />}
               className="text-[var(--muted-text)] hover:text-[var(--text)]"
               title="política de privacidade"
             >

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -40,5 +40,5 @@ export function projMatches(p: Project, f: Filters): boolean {
 /** Ordena tarefas por prioridade (P1 no topo) quando prioSort; estável; não muta a origem. */
 export function sortTasks<T>(tasks: T[], prioSort: boolean, key: (t: T) => number): T[] {
   if (!prioSort) return tasks;
-  return [...tasks].sort((a, b) => key(a) - key(b));
+  return tasks.toSorted((a, b) => key(a) - key(b));
 }

--- a/src/lib/selectors.test.ts
+++ b/src/lib/selectors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { countByStatus, doneTodayCount, blockedCount } from "./selectors";
+import { deriveStats } from "./selectors";
 import type { Project } from "./types";
 
 const projetos: Project[] = [
@@ -34,19 +34,25 @@ const projetos: Project[] = [
 ];
 
 describe("selectors", () => {
-  it("conta por status", () => {
-    expect(countByStatus(projetos)).toEqual({ todo: 1, doing: 1, waiting: 0, done: 2 });
+  it("deriva contagens em uma passada", () => {
+    expect(deriveStats(projetos)).toEqual({
+      byStatus: { todo: 1, doing: 1, waiting: 0, done: 2 },
+      total: 4,
+      done: 2,
+      pendentes: 2,
+      doneToday: 1,
+      blocked: 1,
+    });
   });
 
-  it("conta bloqueadas", () => {
-    expect(blockedCount(projetos)).toBe(1);
-  });
-
-  it("conta concluídas hoje", () => {
-    expect(doneTodayCount(projetos)).toBe(1);
-  });
-
-  it("lista todas as tarefas achatadas", () => {
-    expect(projetos.flatMap((p) => p.sections.flatMap((s) => s.tasks))).toHaveLength(4);
+  it("vazio zera tudo", () => {
+    expect(deriveStats([])).toEqual({
+      byStatus: { todo: 0, doing: 0, waiting: 0, done: 0 },
+      total: 0,
+      done: 0,
+      pendentes: 0,
+      doneToday: 0,
+      blocked: 0,
+    });
   });
 });

--- a/src/lib/selectors.ts
+++ b/src/lib/selectors.ts
@@ -1,17 +1,14 @@
 import { todayISO } from "./date";
 import type { Project, Status, Task } from "./types";
 
-export const allTasks = (projetos: Project[]): Task[] =>
-  projetos.flatMap((p) => p.sections.flatMap((s) => s.tasks));
-
-export function countByStatus(projetos: Project[]): Record<Status, number> {
-  const m: Record<Status, number> = { todo: 0, doing: 0, waiting: 0, done: 0 };
-  for (const t of allTasks(projetos)) m[t.status]++;
-  return m;
+export interface BoardStats {
+  byStatus: Record<Status, number>;
+  total: number;
+  done: number;
+  pendentes: number;
+  doneToday: number;
+  blocked: number;
 }
-
-export const blockedCount = (projetos: Project[]): number =>
-  allTasks(projetos).filter((t) => t.blocked).length;
 
 const localDay = (iso: string): string => {
   const d = new Date(iso);
@@ -20,5 +17,29 @@ const localDay = (iso: string): string => {
   return `${d.getFullYear()}-${m}-${day}`;
 };
 
-export const doneTodayCount = (projetos: Project[]): number =>
-  allTasks(projetos).filter((t) => t.doneAt && localDay(t.doneAt) === todayISO()).length;
+/** Derivada em uma única varredura: evita múltiplos allTasks()/filter() por render. */
+export function deriveStats(projetos: Project[]): BoardStats {
+  const byStatus: Record<Status, number> = { todo: 0, doing: 0, waiting: 0, done: 0 };
+  let total = 0;
+  let done = 0;
+  let doneToday = 0;
+  let blocked = 0;
+  const today = todayISO();
+  for (const p of projetos) {
+    for (const s of p.sections) {
+      for (const t of s.tasks) {
+        total++;
+        byStatus[t.status]++;
+        if (t.blocked) blocked++;
+        if (t.status === "done") {
+          done++;
+          if (t.doneAt && localDay(t.doneAt) === today) doneToday++;
+        }
+      }
+    }
+  }
+  return { byStatus, total, done, pendentes: total - done, doneToday, blocked };
+}
+
+export const allTasks = (projetos: Project[]): Task[] =>
+  projetos.flatMap((p) => p.sections.flatMap((s) => s.tasks));


### PR DESCRIPTION
## O que

Auditoria contra Vercel React Best Practices (skill vercel-react-best-practices). O app é client-only, então as regras críticas (async/server) não se aplicam; as de maior impacto aplicáveis foram corrigidas.

## Mudanças

- **js-combine-iterations / js-cache-function-results**: `countByStatus` + `blockedCount` + `doneTodayCount` varriam todas as tarefas separadamente, e `page.tsx` + `Stats` rodavam isso de novo a cada render (4+ scans). Novo `deriveStats()` em `src/lib/selectors.ts` faz **uma passada única** e devolve `byStatus/total/done/pendentes/doneToday/blocked`.
- **rerender-derived-state**: `page.tsx` memoiza `deriveStats` com `useMemo([projetos])`; `Stats` agora recebe `stats` pronto (sem recalcular) e `FilterChips` reusa `stats.byStatus`/`stats.blocked`.
- **bundle-preload**: links `privacidade` no Topbar e no aviso trocados de `<a>` para `<Link>` do next/link — `/privacidade` é estático e ganha prefetch.
- **js-tosorted-immutable**: `sortTasks` usa `Array.prototype.toSorted` em vez de `[...].sort`.

## Testes

- `selectors.test.ts` reescrito para `deriveStats` (inclui caso vazio).
- `Stats.test.tsx` atualizado para a nova prop `stats` (helpers `statsOf`).
- 168 vitest + 32 e2e verdes; typecheck OK; lint 0 erros (warnings pré-existentes).
