### PR TITLE
feat: arquivar/desarquivar projeto

### DIFF
--- a/e2e/archive.spec.ts
+++ b/e2e/archive.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+
+test("arquivar esconde projeto do board e das stats; toggle mostra com selo e desarquiva", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "+ criar primeiro projeto" }).click();
+  await page.getByLabel("título").fill("Projeto Arquivo");
+  await page.getByRole("button", { name: "criar" }).click();
+  await page.getByLabel("nova tarefa").first().fill("tarefa");
+  await page.getByLabel("nova tarefa").first().press("Enter");
+
+  await page.getByLabel("ações do projeto").click();
+  await page.getByRole("menuitem", { name: "arquivar projeto" }).click();
+
+  await expect(page.getByText("Projeto Arquivo")).toHaveCount(0);
+  await expect(page.getByTestId("stat-total")).toHaveText("0");
+  const chip = page.getByRole("button", { name: /arquivados/ });
+  await expect(chip).toContainText("1");
+
+  await chip.click();
+  await expect(page.getByText("Projeto Arquivo")).toBeVisible();
+  await expect(page.getByText("arquivado", { exact: true })).toBeVisible();
+
+  await page.getByLabel("ações do projeto").click();
+  await page.getByRole("menuitem", { name: "desarquivar projeto" }).click();
+
+  await page.getByRole("button", { name: /arquivados/ }).click();
+  await expect(page.getByText("Projeto Arquivo")).toBeVisible();
+  await expect(page.getByTestId("stat-total")).toHaveText("1");
+  await expect(page.getByRole("button", { name: /arquivados/ })).toContainText("0");
+});
+
+test("arquivamento persiste no reload", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "+ criar primeiro projeto" }).click();
+  await page.getByLabel("título").fill("P Arquivo");
+  await page.getByRole("button", { name: "criar" }).click();
+  await page.getByLabel("ações do projeto").click();
+  await page.getByRole("menuitem", { name: "arquivar projeto" }).click();
+
+  await page.reload();
+  await expect(page.getByText("P Arquivo")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: /arquivados/ })).toContainText("1");
+});

--- a/e2e/export-import.spec.ts
+++ b/e2e/export-import.spec.ts
@@ -135,7 +135,7 @@ test("import de arquivo gigante é rejeitado sem quebrar o estado", async ({ pag
   await expect(page.getByText("nenhum projeto na fila.")).toBeVisible();
 });
 
-test("migra localStorage v1 → v2 no carregamento", async ({ page }) => {
+test("migra localStorage v1 → v3 no carregamento", async ({ page }) => {
   const v1 = {
     state: {
       projetos: [
@@ -166,6 +166,6 @@ test("migra localStorage v1 → v2 no carregamento", async ({ page }) => {
   await expect(page.getByText("tarefa antiga", { exact: false })).toBeVisible();
 
   const stored = await page.evaluate(() => JSON.parse(localStorage.getItem("opsboard.v1") ?? "{}"));
-  expect(stored.version).toBe(2);
+  expect(stored.version).toBe(3);
   expect(stored.state.projetos[0].sections[0].tasks[0]).toMatchObject({ text: "tarefa antiga", prio: 3, doneAt: null });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,6 +22,7 @@ export default function Home() {
   const addProject = useBoard((s) => s.addProject);
   const renameProject = useBoard((s) => s.renameProject);
   const deleteProject = useBoard((s) => s.deleteProject);
+  const toggleProjectArchive = useBoard((s) => s.toggleProjectArchive);
   const addSection = useBoard((s) => s.addSection);
   const renameSection = useBoard((s) => s.renameSection);
   const deleteSection = useBoard((s) => s.deleteSection);
@@ -37,7 +38,7 @@ export default function Home() {
   const importState = useBoard((s) => s.importState);
   const reset = useBoard((s) => s.reset);
   const [confirmClearOpen, setConfirmClearOpen] = useState(false);
-  const { filters, setQuery, toggleStatus, togglePrioSort, toggleView, clear } = useFilters();
+  const { filters, setQuery, toggleStatus, togglePrioSort, toggleView, toggleArchived, clear } = useFilters();
   const { resolvedTheme, setTheme } = useTheme();
   const isDark = resolvedTheme !== "light";
   const toggleTheme = () => setTheme(isDark ? "light" : "dark");
@@ -58,7 +59,11 @@ export default function Home() {
     return () => setStorageErrorHandler(null);
   }, [showToast]);
 
-  const stats = useMemo(() => deriveStats(projetos), [projetos]);
+  const boardProjetos = useMemo(
+    () => (filters.archived ? projetos : projetos.filter((p) => !p.archived)),
+    [projetos, filters.archived],
+  );
+  const stats = useMemo(() => deriveStats(boardProjetos), [boardProjetos]);
   useEffect(() => {
     if (stats.done > prevDone.current) celebrate();
     prevDone.current = stats.done;
@@ -104,6 +109,7 @@ export default function Home() {
   );
 
   const counts = stats.byStatus;
+  const archivedCount = projetos.filter((p) => p.archived).length;
 
   return (
     <div className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
@@ -135,9 +141,12 @@ export default function Home() {
         <FilterChips
           counts={counts}
           blockedCount={stats.blocked}
+          archivedCount={archivedCount}
+          archivedActive={filters.archived}
           active={filters.status}
           filtering={!!filters.query || !!filters.status}
           onToggleStatus={toggleStatus}
+          onToggleArchived={toggleArchived}
           onClear={clear}
         />
       </div>
@@ -147,13 +156,14 @@ export default function Home() {
 
       <main className="mx-auto max-w-5xl px-4 py-6">
         <Board
-          projetos={projetos}
+          projetos={boardProjetos}
           filters={filters}
           onNewProject={() => setNewProjectOpen(true)}
           projectActions={{
             onAddSection: (pid, title) => addSection(pid, title),
             onRename: (id, title, blocked) => renameProject(id, title, blocked),
             onDelete: (id) => deleteProject(id),
+            onToggleArchive: toggleProjectArchive,
           }}
           sectionActions={{
             onToggle: (pid, sid) => toggleSection(pid, sid),

--- a/src/components/client/FilterChips.test.tsx
+++ b/src/components/client/FilterChips.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { FilterChips } from "./FilterChips";
+
+const base = {
+  counts: { todo: 2, doing: 1, waiting: 0, done: 3 },
+  blockedCount: 1,
+  active: null as null,
+  filtering: false,
+  onToggleStatus: vi.fn(),
+  onClear: vi.fn(),
+};
+
+describe("FilterChips", () => {
+  it("mostra contagem de arquivados e alterna visibilidade", async () => {
+    const onToggleArchived = vi.fn();
+    render(<FilterChips {...base} archivedCount={4} archivedActive={false} onToggleArchived={onToggleArchived} />);
+    const chip = screen.getByRole("button", { name: /arquivados/ });
+    expect(chip).toHaveTextContent("4");
+    expect(chip).toHaveAttribute("aria-pressed", "false");
+    await userEvent.click(chip);
+    expect(onToggleArchived).toHaveBeenCalledTimes(1);
+  });
+
+  it("marca ativo quando mostrando arquivados", () => {
+    render(<FilterChips {...base} archivedCount={1} archivedActive={true} onToggleArchived={() => {}} />);
+    expect(screen.getByRole("button", { name: /arquivados/ })).toHaveAttribute("aria-pressed", "true");
+  });
+});

--- a/src/components/client/FilterChips.tsx
+++ b/src/components/client/FilterChips.tsx
@@ -20,13 +20,26 @@ const CHIPS: ChipDef[] = [
 interface FilterChipsProps {
   counts: Record<Status, number>;
   blockedCount: number;
+  archivedCount: number;
+  archivedActive: boolean;
   active: StatusFilter;
   filtering: boolean;
   onToggleStatus: (status: StatusFilter) => void;
+  onToggleArchived: () => void;
   onClear: () => void;
 }
 
-export function FilterChips({ counts, blockedCount, active, filtering, onToggleStatus, onClear }: FilterChipsProps) {
+export function FilterChips({
+  counts,
+  blockedCount,
+  archivedCount,
+  archivedActive,
+  active,
+  filtering,
+  onToggleStatus,
+  onToggleArchived,
+  onClear,
+}: FilterChipsProps) {
   return (
     <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="filtros por status">
       {CHIPS.map(({ key, label, cls }) => {
@@ -48,6 +61,18 @@ export function FilterChips({ counts, blockedCount, active, filtering, onToggleS
           </Button>
         );
       })}
+      <Button
+        type="button"
+        variant={archivedActive ? "outline" : "ghost"}
+        size="xs"
+        onClick={onToggleArchived}
+        title="mostrar/ocultar projetos arquivados"
+        aria-pressed={archivedActive}
+        className={`text-violet-400 ${archivedActive ? "border-current bg-[var(--hover)]" : "opacity-60"}`}
+      >
+        arquivados
+        <span className="opacity-60">{archivedCount}</span>
+      </Button>
       {filtering && (
         <Button
           type="button"

--- a/src/components/client/Stats.test.tsx
+++ b/src/components/client/Stats.test.tsx
@@ -10,7 +10,7 @@ import type { Project } from "../../lib/types";
 const projeto = (tasks: Project["sections"][number]["tasks"]): Project => ({
   id: "p1",
   title: "A",
-  blocked: false,
+  blocked: false, archived: false,
   sections: [{ id: "s1", title: "geral", tasks, notes: "", collapsed: false }],
 });
 

--- a/src/components/client/board/Board.test.tsx
+++ b/src/components/client/board/Board.test.tsx
@@ -8,7 +8,7 @@ import type { Project } from "@/lib/types";
 const projeto: Project = {
   id: "p1",
   title: "Alfa",
-  blocked: false,
+  blocked: false, archived: false,
   sections: [
     { id: "s1", title: "geral", notes: "", collapsed: false, tasks: [
       { id: "t1", text: "tarefa alfa", status: "todo", note: "", blocked: false, prio: 3, due: "", doneAt: null },
@@ -24,6 +24,7 @@ const base = (over: Partial<BoardProps> = {}): BoardProps => ({
     onAddSection: vi.fn(),
     onRename: vi.fn(),
     onDelete: vi.fn(),
+    onToggleArchive: vi.fn(),
   },
   sectionActions: {
     onToggle: vi.fn(),

--- a/src/components/client/board/Board.tsx
+++ b/src/components/client/board/Board.tsx
@@ -10,6 +10,7 @@ export interface BoardProjectActions {
   onAddSection: (pid: string, title: string) => void;
   onRename: (id: string, title: string, blocked: boolean) => void;
   onDelete: (id: string) => void;
+  onToggleArchive: (id: string) => void;
 }
 
 export interface BoardSectionActions {
@@ -127,6 +128,7 @@ export function Board({ projetos, filters, onNewProject, projectActions, section
             onAddSection={(title) => projectActions.onAddSection(p.id, title)}
             onRename={(id, title, blocked) => projectActions.onRename(id, title, blocked)}
             onDelete={(id) => projectActions.onDelete(id)}
+            onToggleArchive={() => projectActions.onToggleArchive(p.id)}
             prioSort={filters.prioSort}
           />
         ))}

--- a/src/components/client/board/ProjectCard.test.tsx
+++ b/src/components/client/board/ProjectCard.test.tsx
@@ -7,7 +7,7 @@ const base = (over: Partial<ProjectCardProps> = {}): ProjectCardProps => ({
   project: {
     id: "p1",
     title: "Projeto Alfa",
-    blocked: false,
+    blocked: false, archived: false,
     sections: [
       { id: "s1", title: "geral", notes: "", collapsed: false, tasks: [
         { id: "t1", text: "fazer", status: "todo", note: "", blocked: false, prio: 3, due: "", doneAt: null },
@@ -32,6 +32,7 @@ const base = (over: Partial<ProjectCardProps> = {}): ProjectCardProps => ({
   onAddSection: vi.fn(),
   onRename: vi.fn(),
   onDelete: vi.fn(),
+  onToggleArchive: vi.fn(),
   ...over,
 });
 
@@ -91,5 +92,24 @@ describe("ProjectCard", () => {
     await userEvent.click(await screen.findByRole("menuitem", { name: "excluir projeto" }));
     expect(p.onDelete).not.toHaveBeenCalled();
     confirmSpy.mockRestore();
+  });
+
+  it("arquiva via menu de ações", async () => {
+    const p = base();
+    render(<ProjectCard {...p} />);
+    await openMenu();
+    await userEvent.click(await screen.findByRole("menuitem", { name: "arquivar projeto" }));
+    expect(p.onToggleArchive).toHaveBeenCalledTimes(1);
+  });
+
+  it("mostra selo arquivado e desarquiva via menu", async () => {
+    const p = base({
+      project: { ...base().project, archived: true },
+    });
+    render(<ProjectCard {...p} />);
+    expect(screen.getByText("arquivado")).toBeTruthy();
+    await openMenu();
+    await userEvent.click(await screen.findByRole("menuitem", { name: "desarquivar projeto" }));
+    expect(p.onToggleArchive).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/client/board/ProjectCard.tsx
+++ b/src/components/client/board/ProjectCard.tsx
@@ -28,6 +28,7 @@ export interface ProjectCardProps {
   onAddSection: (title: string) => void;
   onRename: (id: string, title: string, blocked: boolean) => void;
   onDelete: (id: string) => void;
+  onToggleArchive: () => void;
   prioSort?: boolean;
 }
 
@@ -36,7 +37,7 @@ type ModalState =
   | { kind: "add-section" }
   | null;
 
-export function ProjectCard({ project, collectActions, onAddSection, onRename, onDelete, prioSort }: ProjectCardProps) {
+export function ProjectCard({ project, collectActions, onAddSection, onRename, onDelete, onToggleArchive, prioSort }: ProjectCardProps) {
   const [modal, setModal] = useState<ModalState>(null);
   const actions = collectActions(project.id);
 
@@ -59,6 +60,11 @@ export function ProjectCard({ project, collectActions, onAddSection, onRename, o
         {project.blocked && (
           <Badge variant="destructive" className="rounded-[4px] px-1.5 text-[10px] font-bold uppercase tracking-[0.08em]">
             stuck
+          </Badge>
+        )}
+        {project.archived && (
+          <Badge variant="outline" className="rounded-[4px] px-1.5 text-[10px] font-bold uppercase tracking-[0.08em]">
+            arquivado
           </Badge>
         )}
         <span className="ml-auto flex items-center gap-1">
@@ -88,6 +94,9 @@ export function ProjectCard({ project, collectActions, onAddSection, onRename, o
                 onClick={() => setModal({ kind: "rename" })}
               >
                 renomear projeto
+              </DropdownMenuItem>
+              <DropdownMenuItem className="text-xs" onClick={onToggleArchive}>
+                {project.archived ? "desarquivar projeto" : "arquivar projeto"}
               </DropdownMenuItem>
               <DropdownMenuSeparator className="bg-[var(--line)]" />
               <DropdownMenuItem

--- a/src/components/client/dnd/Kanban.test.tsx
+++ b/src/components/client/dnd/Kanban.test.tsx
@@ -6,7 +6,7 @@ import type { Project } from "@/lib/types";
 const projeto = (): Project => ({
   id: "p1",
   title: "P",
-  blocked: false,
+  blocked: false, archived: false,
   sections: [
     {
       id: "s1",

--- a/src/hooks/useFilters.test.tsx
+++ b/src/hooks/useFilters.test.tsx
@@ -10,6 +10,7 @@ describe("useFilters", () => {
       status: null,
       prioSort: false,
       view: "list",
+      archived: false,
     });
   });
 

--- a/src/hooks/useFilters.ts
+++ b/src/hooks/useFilters.ts
@@ -20,9 +20,13 @@ export function useFilters(initial: Filters = defaultFilters) {
     setFilters((f) => ({ ...f, view: (f.view === "list" ? "kanban" : "list") as View }));
   }, []);
 
+  const toggleArchived = useCallback(() => {
+    setFilters((f) => ({ ...f, archived: !f.archived }));
+  }, []);
+
   const clear = useCallback(() => {
     setFilters((f) => ({ ...f, query: "", status: null }));
   }, []);
 
-  return { filters, setQuery, toggleStatus, togglePrioSort, toggleView, clear };
+  return { filters, setQuery, toggleStatus, togglePrioSort, toggleView, toggleArchived, clear };
 }

--- a/src/lib/dnd.test.ts
+++ b/src/lib/dnd.test.ts
@@ -5,7 +5,7 @@ import type { Project } from "./types";
 const projeto = (over: Partial<Project> = {}): Project => ({
   id: "p1",
   title: "P",
-  blocked: false,
+  blocked: false, archived: false,
   sections: [
     {
       id: "s1",

--- a/src/lib/filter.test.ts
+++ b/src/lib/filter.test.ts
@@ -26,12 +26,12 @@ const section = (over: Partial<Section> = {}): Section => ({
 const project = (over: Partial<Project> = {}): Project => ({
   id: "p1",
   title: "Projeto Alfa",
-  blocked: false,
+  blocked: false, archived: false,
   sections: [section()],
   ...over,
 });
 
-const none: Filters = { query: "", status: null, prioSort: false, view: "list" };
+const none: Filters = { query: "", status: null, prioSort: false, view: "list", archived: false };
 
 describe("matchTask", () => {
   it("casa qualquer tarefa sem filtros", () => {

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -8,9 +8,10 @@ export interface Filters {
   status: StatusFilter;
   prioSort: boolean;
   view: View;
+  archived: boolean;
 }
 
-export const defaultFilters: Filters = { query: "", status: null, prioSort: false, view: "list" };
+export const defaultFilters: Filters = { query: "", status: null, prioSort: false, view: "list", archived: false };
 
 export const isFiltering = (f: Filters): boolean => !!f.query || !!f.status;
 

--- a/src/lib/io.test.ts
+++ b/src/lib/io.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from "vitest";
 import { exportJson, MAX_BYTES, MAX_PROJECTS, MAX_TASKS, parseImport } from "./io";
 import type { Project } from "./types";
 
-const projeto = (): Project => ({
+const projeto = (over: Partial<Project> = {}): Project => ({
   id: "p1",
   title: "P",
   blocked: false,
+  archived: false,
   sections: [
     {
       id: "s1",
@@ -17,6 +18,7 @@ const projeto = (): Project => ({
       ],
     },
   ],
+  ...over,
 });
 
 describe("exportJson", () => {
@@ -30,6 +32,11 @@ describe("exportJson", () => {
 describe("parseImport", () => {
   it("aceita JSON válido", () => {
     expect(parseImport(exportJson([projeto()]))).toHaveLength(1);
+  });
+
+  it("preserva archived no round-trip export→import", () => {
+    const out = parseImport(exportJson([projeto({ archived: true })]));
+    expect(out[0].archived).toBe(true);
   });
 
   it("rejeita JSON inválido", () => {

--- a/src/lib/io.ts
+++ b/src/lib/io.ts
@@ -49,6 +49,7 @@ const isProject = (p: unknown): boolean => {
     o.id.length > 0 &&
     typeof o.title === "string" &&
     typeof o.blocked === "boolean" &&
+    (o.archived === undefined || typeof o.archived === "boolean") &&
     Array.isArray(o.sections) &&
     o.sections.every(isSection)
   );

--- a/src/lib/migrate.test.ts
+++ b/src/lib/migrate.test.ts
@@ -40,6 +40,12 @@ describe("migrateLegacy", () => {
     const out = migrateLegacy({ projetos: [{ id: "p1", title: "P" }] });
     expect(out!.projetos[0].sections).toEqual([]);
     expect(out!.projetos[0].blocked).toBe(false);
+    expect(out!.projetos[0].archived).toBe(false);
+  });
+
+  it("preserva archived quando presente", () => {
+    const out = migrateLegacy({ projetos: [{ id: "p1", title: "P", archived: true }] });
+    expect(out!.projetos[0].archived).toBe(true);
   });
 
   it("preserva dados existentes intactos", () => {
@@ -75,7 +81,7 @@ describe("migrateLegacy", () => {
   });
 
   it("mantém versão de schema estável e exportada", () => {
-    expect(SCHEMA_VERSION).toBe(2);
+    expect(SCHEMA_VERSION).toBe(3);
   });
 });
 

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -1,6 +1,6 @@
 import { PRIOS, STATUSES, type Prio, type Project, type Section, type Status, type Task } from "./types";
 
-export const SCHEMA_VERSION = 2;
+export const SCHEMA_VERSION = 3;
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -34,6 +34,7 @@ function normProject(p: UnknownRecord | undefined): Project {
     id: String(p?.id ?? ""),
     title: String(p?.title ?? ""),
     blocked: Boolean(p?.blocked),
+    archived: Boolean(p?.archived),
     sections: Array.isArray(p?.sections) ? p.sections.map((s) => normSection(s as UnknownRecord)) : [],
   };
 }

--- a/src/lib/selectors.test.ts
+++ b/src/lib/selectors.test.ts
@@ -7,6 +7,7 @@ const projetos: Project[] = [
     id: "p1",
     title: "A",
     blocked: true,
+    archived: false,
     sections: [
       {
         id: "s1",

--- a/src/lib/store.test.ts
+++ b/src/lib/store.test.ts
@@ -6,6 +6,7 @@ const seedProjeto = (): Project => ({
   id: "p1",
   title: "Projeto A",
   blocked: false,
+  archived: false,
   sections: [
     { id: "s1", title: "geral", notes: "", collapsed: false, tasks: [
       { id: "t1", text: "tarefa 1", status: "todo" as const, note: "", blocked: false, prio: 3, due: "", doneAt: null },
@@ -142,9 +143,18 @@ describe("board store", () => {
   });
 
   it("importState substitui estado", () => {
-    const novo = [{ id: "x", title: "Importado", blocked: false, sections: [] }];
+    const novo = [{ id: "x", title: "Importado", blocked: false, archived: false, sections: [] }];
     store.getState().importState(novo);
     expect(store.getState().projetos).toEqual(novo);
+  });
+
+  it("toggleProjectArchive arquiva e desarquiva", () => {
+    store.getState().addProject("A");
+    const pid = store.getState().projetos[0].id;
+    store.getState().toggleProjectArchive(pid);
+    expect(store.getState().projetos[0].archived).toBe(true);
+    store.getState().toggleProjectArchive(pid);
+    expect(store.getState().projetos[0].archived).toBe(false);
   });
 });
 
@@ -199,6 +209,18 @@ describe("persistência", () => {
     expect(t.due).toBe("5");
     expect(t.note).toBe("42");
     expect(t.doneAt).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("migra esquema v2 sem archived (default false aplicado)", () => {
+    localStorage.setItem(
+      "opsboard.v1",
+      JSON.stringify({
+        state: { projetos: [{ id: "p1", title: "P", blocked: false, sections: [] }] },
+        version: 2,
+      }),
+    );
+    const s = createBoardStore();
+    expect(s.getState().projetos[0].archived).toBe(false);
   });
 
   it("estado vazio volta com projetos vazios", () => {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -27,6 +27,7 @@ interface BoardStore {
   addProject: (title: string) => void;
   renameProject: (id: string, title: string, blocked: boolean) => void;
   deleteProject: (id: string) => void;
+  toggleProjectArchive: (id: string) => void;
   addSection: (pid: string, title: string) => void;
   renameSection: (pid: string, sid: string, title: string) => void;
   deleteSection: (pid: string, sid: string) => void;
@@ -78,6 +79,7 @@ export function createBoardStore(initial: Project[] = []) {
                 id: uid(),
                 title,
                 blocked: false,
+                archived: false,
                 sections: [{ id: uid(), title: "geral", tasks: [], notes: "", collapsed: false }],
               },
             ],
@@ -89,6 +91,11 @@ export function createBoardStore(initial: Project[] = []) {
           })),
 
         deleteProject: (id) => set((s) => ({ projetos: s.projetos.filter((p) => p.id !== id) })),
+
+        toggleProjectArchive: (id) =>
+          set((s) => ({
+            projetos: s.projetos.map((p) => (p.id === id ? { ...p, archived: !p.archived } : p)),
+          })),
 
         addSection: (pid, title) =>
           set((s) => ({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,6 +24,7 @@ export interface Project {
   id: string;
   title: string;
   blocked: boolean;
+  archived: boolean;
   sections: Section[];
 }
 


### PR DESCRIPTION
## O que

Fechar #57: arquivar e desarquivar projeto.

## Comportamento

- Campo `archived` no Project (schema **v3**; migração v2→v3 aplica default `false`)
- Projetos arquivados somem do board e das stats
- Chip **arquivados (n)** nos filtros: ativo mostra todos (arquivados com selo `arquivado`), inativo esconde
- `arquivar projeto` / `desarquivar projeto` no menu de ações do projeto (⋯)
- Export/import preservam `archived`; backups v2 (sem o campo) continuam importáveis

## Verificação

- Unit (178): migrate v3 defaults, store `toggleProjectArchive`, FilterChips chip + aria-pressed, ProjectCard selo/menu, io round-trip
- E2e (34, +2): arquivar esconde do board/stats + toggle mostra com selo + desarquiva; persistência no reload
- Typecheck OK, lint 0 erros
