### PR TITLE
fix: filtro de arquivados real + limpar + toast

### DIFF
--- a/e2e/archive.spec.ts
+++ b/e2e/archive.spec.ts
@@ -1,39 +1,89 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
-test("arquivar esconde projeto do board e das stats; toggle mostra com selo e desarquiva", async ({ page }) => {
-  await page.goto("/");
-  await page.getByRole("button", { name: "+ criar primeiro projeto" }).click();
-  await page.getByLabel("título").fill("Projeto Arquivo");
+async function createProject(page: Page, title: string) {
+  const empty = page.getByRole("button", { name: "+ criar primeiro projeto" });
+  if (await empty.isVisible()) {
+    await empty.click();
+  } else {
+    await page.getByRole("button", { name: "+ projeto" }).click();
+  }
+  await page.getByLabel("título").fill(title);
   await page.getByRole("button", { name: "criar" }).click();
-  await page.getByLabel("nova tarefa").first().fill("tarefa");
-  await page.getByLabel("nova tarefa").first().press("Enter");
+}
 
-  await page.getByLabel("ações do projeto").click();
+const projectCard = (page: Page, title: string) =>
+  page.locator("section.rounded-lg").filter({ hasText: title });
+
+async function addTask(page: Page, projectTitle: string, text: string) {
+  const input = projectCard(page, projectTitle).getByLabel("nova tarefa").first();
+  await input.fill(text);
+  await input.press("Enter");
+}
+
+const archiveMenu = (page: Page, title: string) =>
+  projectCard(page, title).getByLabel("ações do projeto");
+
+test("chip arquivados filtra de verdade: só arquivados visíveis; limpar reseta", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "Ativo A");
+  await addTask(page, "Ativo A", "tarefa ativa");
+  await createProject(page, "Arquivo P");
+  await addTask(page, "Arquivo P", "tarefa antiga");
+
+  await archiveMenu(page, "Arquivo P").click();
   await page.getByRole("menuitem", { name: "arquivar projeto" }).click();
 
-  await expect(page.getByText("Projeto Arquivo")).toHaveCount(0);
-  await expect(page.getByTestId("stat-total")).toHaveText("0");
+  await expect(page.getByText("Arquivo P")).toHaveCount(0);
+  await expect(page.getByTestId("stat-total")).toHaveText("1");
   const chip = page.getByRole("button", { name: /arquivados/ });
   await expect(chip).toContainText("1");
+  await expect(page.getByRole("button", { name: "✕ limpar" })).toHaveCount(0);
 
   await chip.click();
-  await expect(page.getByText("Projeto Arquivo")).toBeVisible();
+  await expect(page.getByText("Arquivo P")).toBeVisible();
+  await expect(page.getByText("Ativo A")).toHaveCount(0);
   await expect(page.getByText("arquivado", { exact: true })).toBeVisible();
+  await expect(page.getByTestId("stat-total")).toHaveText("1");
+  await expect(page.getByRole("button", { name: "✕ limpar" })).toBeVisible();
 
   await page.getByLabel("ações do projeto").click();
   await page.getByRole("menuitem", { name: "desarquivar projeto" }).click();
-
-  await page.getByRole("button", { name: /arquivados/ }).click();
-  await expect(page.getByText("Projeto Arquivo")).toBeVisible();
-  await expect(page.getByTestId("stat-total")).toHaveText("1");
+  await expect(page.getByText("projeto desarquivado")).toBeVisible();
+  await expect(page.getByText("Arquivo P")).toHaveCount(0);
   await expect(page.getByRole("button", { name: /arquivados/ })).toContainText("0");
+
+  await page.getByRole("button", { name: "✕ limpar" }).click();
+  await expect(page.getByText("Arquivo P")).toBeVisible();
+  await expect(page.getByTestId("stat-total")).toHaveText("2");
+  await expect(page.getByRole("button", { name: /arquivados/ })).toHaveAttribute("aria-pressed", "false");
+});
+
+test("filtro de status combina com arquivados", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "P Done");
+  await addTask(page, "P Done", "terminada");
+  await page.getByLabel("alternar concluída").first().click();
+  await createProject(page, "P Todo");
+  await addTask(page, "P Todo", "pendente");
+
+  await archiveMenu(page, "P Done").click();
+  await page.getByRole("menuitem", { name: "arquivar projeto" }).click();
+  await archiveMenu(page, "P Todo").click();
+  await page.getByRole("menuitem", { name: "arquivar projeto" }).click();
+  await page.getByRole("button", { name: /arquivados/ }).click();
+
+  await page.getByRole("button", { name: "done" }).click();
+  await expect(page.getByText("terminada")).toBeVisible();
+  await expect(page.getByText("P Todo")).toHaveCount(0);
+
+  await page.getByRole("button", { name: /^todo/ }).click();
+  await expect(page.getByText("pendente", { exact: true })).toBeVisible();
+  await expect(page.getByText("P Done")).toHaveCount(0);
 });
 
 test("arquivamento persiste no reload", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("button", { name: "+ criar primeiro projeto" }).click();
-  await page.getByLabel("título").fill("P Arquivo");
-  await page.getByRole("button", { name: "criar" }).click();
+  await createProject(page, "P Arquivo");
   await page.getByLabel("ações do projeto").click();
   await page.getByRole("menuitem", { name: "arquivar projeto" }).click();
 

--- a/e2e/rights.spec.ts
+++ b/e2e/rights.spec.ts
@@ -7,6 +7,7 @@ const SEED = {
       id: "p1",
       title: "alpha",
       blocked: false,
+      archived: false,
       sections: [
         {
           id: "s1",
@@ -21,6 +22,7 @@ const SEED = {
       id: "p2",
       title: "beta",
       blocked: true,
+      archived: false,
       sections: [
         {
           id: "s2",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import { useTheme } from "next-themes";
 import { celebrate } from "@/lib/celebrate";
 import { exportJson, parseImport } from "@/lib/io";
 import { deriveStats } from "@/lib/selectors";
+import { visibleProjetos } from "@/lib/filter";
 import { useBoard, setStorageErrorHandler } from "@/lib/store";
 import { Dialog, DialogClose, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -59,15 +60,22 @@ export default function Home() {
     return () => setStorageErrorHandler(null);
   }, [showToast]);
 
-  const boardProjetos = useMemo(
-    () => (filters.archived ? projetos : projetos.filter((p) => !p.archived)),
-    [projetos, filters.archived],
-  );
+  const boardProjetos = useMemo(() => visibleProjetos(projetos, filters), [projetos, filters]);
   const stats = useMemo(() => deriveStats(boardProjetos), [boardProjetos]);
   useEffect(() => {
     if (stats.done > prevDone.current) celebrate();
     prevDone.current = stats.done;
   }, [stats.done]);
+
+  const handleToggleArchive = useCallback(
+    (id: string) => {
+      const p = projetos.find((x) => x.id === id);
+      if (!p) return;
+      toggleProjectArchive(id);
+      showToast(p.archived ? "projeto desarquivado" : "projeto arquivado");
+    },
+    [projetos, toggleProjectArchive, showToast],
+  );
 
   const handleExport = useCallback(() => {
     const blob = new Blob([exportJson(projetos)], { type: "application/json" });
@@ -144,7 +152,7 @@ export default function Home() {
           archivedCount={archivedCount}
           archivedActive={filters.archived}
           active={filters.status}
-          filtering={!!filters.query || !!filters.status}
+          filtering={!!filters.query || !!filters.status || filters.archived}
           onToggleStatus={toggleStatus}
           onToggleArchived={toggleArchived}
           onClear={clear}
@@ -163,7 +171,7 @@ export default function Home() {
             onAddSection: (pid, title) => addSection(pid, title),
             onRename: (id, title, blocked) => renameProject(id, title, blocked),
             onDelete: (id) => deleteProject(id),
-            onToggleArchive: toggleProjectArchive,
+            onToggleArchive: handleToggleArchive,
           }}
           sectionActions={{
             onToggle: (pid, sid) => toggleSection(pid, sid),

--- a/src/components/client/FilterChips.tsx
+++ b/src/components/client/FilterChips.tsx
@@ -80,7 +80,7 @@ export function FilterChips({
           size="xs"
           onClick={onClear}
           className="font-bold text-[var(--muted-text)]"
-          title="limpar filtros (status + busca)"
+          title="limpar filtros (status, busca, arquivados)"
         >
           ✕ limpar
         </Button>

--- a/src/hooks/useFilters.test.tsx
+++ b/src/hooks/useFilters.test.tsx
@@ -57,10 +57,12 @@ describe("useFilters", () => {
       result.current.toggleStatus("todo");
       result.current.toggleView();
       result.current.togglePrioSort();
+      result.current.toggleArchived();
     });
     act(() => result.current.clear());
     expect(result.current.filters.query).toBe("");
     expect(result.current.filters.status).toBeNull();
+    expect(result.current.filters.archived).toBe(false);
     expect(result.current.filters.view).toBe("kanban");
     expect(result.current.filters.prioSort).toBe(true);
   });

--- a/src/hooks/useFilters.ts
+++ b/src/hooks/useFilters.ts
@@ -25,7 +25,7 @@ export function useFilters(initial: Filters = defaultFilters) {
   }, []);
 
   const clear = useCallback(() => {
-    setFilters((f) => ({ ...f, query: "", status: null }));
+    setFilters((f) => ({ ...f, query: "", status: null, archived: false }));
   }, []);
 
   return { filters, setQuery, toggleStatus, togglePrioSort, toggleView, toggleArchived, clear };

--- a/src/lib/filter.test.ts
+++ b/src/lib/filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isFiltering, matchTask, projMatches, sectMatches, sortTasks, type Filters } from "./filter";
+import { isFiltering, matchTask, projMatches, sectMatches, sortTasks, visibleProjetos, type Filters } from "./filter";
 import type { Project, Section, Task } from "./types";
 
 const task = (over: Partial<Task> = {}): Task => ({
@@ -133,5 +133,25 @@ describe("isFiltering", () => {
     expect(isFiltering({ ...none, query: "x" })).toBe(true);
     expect(isFiltering({ ...none, status: "todo" })).toBe(true);
     expect(isFiltering({ ...none, status: "blocked" })).toBe(true);
+  });
+});
+
+describe("visibleProjetos", () => {
+  const ativo = project({ id: "a", title: "Ativo" });
+  const arquivado = project({ id: "b", title: "Arquivado", archived: true });
+  const projetos = [ativo, arquivado];
+
+  it("sem chip arquivados, mostra só projetos ativos", () => {
+    expect(visibleProjetos(projetos, none)).toEqual([ativo]);
+  });
+
+  it("com chip arquivados ativo, mostra só arquivados", () => {
+    expect(visibleProjetos(projetos, { ...none, archived: true })).toEqual([arquivado]);
+  });
+
+  it("ordem preservada e não muta a origem", () => {
+    const out = visibleProjetos([arquivado, ativo], none);
+    expect(out).toEqual([ativo]);
+    expect(projetos).toHaveLength(2);
   });
 });

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -43,3 +43,7 @@ export function sortTasks<T>(tasks: T[], prioSort: boolean, key: (t: T) => numbe
   if (!prioSort) return tasks;
   return tasks.toSorted((a, b) => key(a) - key(b));
 }
+
+/** Projetos visíveis no board: chip arquivados ligado mostra só arquivados; desligado, só ativos. */
+export const visibleProjetos = (projetos: Project[], f: Filters): Project[] =>
+  projetos.filter((p) => p.archived === f.archived);

--- a/src/lib/io.test.ts
+++ b/src/lib/io.test.ts
@@ -39,6 +39,13 @@ describe("parseImport", () => {
     expect(out[0].archived).toBe(true);
   });
 
+  it("normaliza projeto sem archived (backup v2) para false", () => {
+    const raw = JSON.parse(exportJson([projeto()]));
+    delete raw.projetos[0].archived;
+    const out = parseImport(JSON.stringify(raw));
+    expect(out[0].archived).toBe(false);
+  });
+
   it("rejeita JSON inválido", () => {
     expect(() => parseImport("não é json")).toThrow(/formato inválido/i);
   });

--- a/src/lib/io.ts
+++ b/src/lib/io.ts
@@ -84,7 +84,7 @@ export function parseImport(raw: string): Project[] {
     throw new Error("dados inválidos: estrutura de projeto, seção ou tarefa incorreta");
   }
 
-  const list = projetos as Project[];
+  const list = (projetos as Project[]).map((p) => ({ ...p, archived: Boolean(p.archived) }));
   const ids = new Set<string>();
   let sections = 0;
   let tasks = 0;


### PR DESCRIPTION
Close #59

## O que mudou

O chip **arquivados** agora é um filtro real, igual aos de status:

- **Só arquivados**: com o chip ligado, só projetos arquivados aparecem (antes mostrava todos).
- **✕ limpar** aparece sempre que o chip está ativo e reseta `archived` junto com status/busca.
- **Toast** ao arquivar/desarquivar: "projeto arquivado" / "projeto desarquivado".
- Stats refletem o que está visível (board + total).
- **Import de backup v2**: projetos sem o campo `archived` são normalizados para `false` (antes sumiam do board).

## Testes

- Unit: `visibleProjetos` (ativo/arquivado/ordem preservada), `clear()` reseta archived, import normaliza v2 → **180 passando**
- e2e: chip filtra de verdade + limpar reseta; status combina com arquivados; persiste no reload → **34 passando**
- `typecheck` + `lint` OK
