### PR TITLE
UX/UI A — fundação visual, tokens e acessibilidade

### DIFF
--- a/docs/superpowers/specs/2026-08-15-ux-ui-design.md
+++ b/docs/superpowers/specs/2026-08-15-ux-ui-design.md
@@ -1,0 +1,61 @@
+# OpsBoard — UX/UI: Refino de identidade + fundação a11y (programa de 4 issues)
+
+Data: 2026-08-15 · Escopo: programa em 4 issues sequenciais (A→D), cada uma com PR próprio, TDD (unit vitest + e2e Playwright), CI gate `check`, merge squash após aprovação do usuário.
+
+## Contexto
+
+Auditoria dual-agent (impeccable critique + audit técnico): Health 13/20, Nielsen 27/40. Identidade terminal executada com coerência (manter). Problemas: tema claro quebra contraste (1.5–2.8:1), sem undo/confirmação em dados, confete no momento errado, atalho "n" morto, kanban é beco sem saída, `--dim/--dimmer` ilegíveis, console errors base-ui.
+
+## Issue A — Fundação visual/a11y
+
+**Tokens de status por tema** (novos `--todo`, `--violet`; overrides em `html.light`):
+
+| Token | dark | light |
+|-------|------|-------|
+| `--fired` (done) | `#34d399` (10.12:1) | `#047857` (4.98) |
+| `--flow` (doing) | `#22d3ee` | `#0e7490` (4.86) |
+| `--warn` (waiting) | `#fbbf24` | `#b45309` (4.56) |
+| `--gave` (blocked) | `#f87171` | `#b91c1c` (5.87) |
+| `--todo` | `#94a3b8` | `#475569` (6.88) |
+| `--violet` (arquivados) | `#a78bfa` | `#7c3aed` (5.17) |
+
+**`--dim/--dimmer` sólidos** (hierarquia preservada, interativo ≥4.5:1): dark `#7d8a9c`/`#707c8c`; light `#5b6572`/`#64707f`.
+
+**Migrações**:
+- Cores cruas → tokens: FilterChips (cls chips, violet), Stats (pendentes/concluídas/hoje/prio), TaskRow (LED, prio, due), Kanban (colunas), Section (outline drag), Topbar (`##`, `>`).
+- `bg-red-500 hover:bg-red-600` (page.tsx "apagar tudo") → variant destrutiva; `text-[#0a0d12]` (Board CTA) → `text-primary-foreground`; `border-zinc-600`/`decoration-zinc-700` → tokens.
+- Console errors base-ui: `render={<Link/>}` com `nativeButton={false}` (Topbar.tsx privacidade, PrivacyNotice).
+
+**Hierarquia**: task text 12.5→13px, badges 10→11px, LED com hit-area ≥24px (wrapper com padding, dot 8px), touch targets xs≥28px onde viável.
+
+## Issue B — Prevenção de perda de dados
+
+- **Undo**: middleware de snapshot no store (zustand), stack sessão-only (~50), push antes de mutações de dados (add/rename/delete/move/toggle/import), `undo()` + `canUndo`. Atalho `Ctrl+Z`/`⌘Z` com guard: não interceptar quando foco em input/textarea. Toast "desfeito".
+- **Import**: dialog de confirmação (padrão do wipe-all): "importar substitui os N projetos atuais? exporte um backup antes".
+- **Delete tarefa/seção/projeto**: protegidos por undo; remover `window.confirm` do projeto (consistência).
+
+## Issue C — Feedback e ajuda
+
+- **Confete**: disparar na transição was→done dentro de `toggleTask`/`setTaskStatus` (via wrapper nas taskActions da página, olhando o estado antes), remover useEffect derivado de `stats.done` (page.tsx:67-70).
+- **Atalho "n"**: foca o primeiro input `aria-label="nova tarefa"` visível (+ scrollIntoView).
+- **Ajuda**: "?" abre Modal persistente com tabela de atalhos e dicas de drag (substitui toast 1.6s).
+- **Hints corretos**: "status-dock" → descrever o que existe (lista: arraste entre seções/projetos; kanban: arraste entre colunas).
+- **Toasts**: `role="status"` + `aria-live="polite"`, duração 2.5s, sem sobrepor footer (posição acima).
+
+## Issue D — Fluxos que travam
+
+- **Kanban rico**: cards mostram prio (P1–P3 com cor), due (overdue/duesoon destacados), blocked glyph, indicador de nota; clique no card abre o Modal de edição (mesmos campos do list). Kanban recebe prop de edit.
+- **Empty state de filtro**: "nada casa com o filtro." ganha CTA "✕ limpar filtros" (Board recebe `onClear`).
+- **Drag em lista**: droppable no fim da seção → `resolveDrop` append no final (hoje só insere antes de overTid ou index 0).
+- **Section header**: `role="button"` div → `<button>` nativo com `aria-expanded`; `stopPropagation` também no keydown do dropdown trigger (Enter não colapsa a seção).
+
+## Fora de escopo (registrar, não fazer)
+
+- Command palette, undo persistido entre sessões, milestone diário de confete, merge por ID no import, redesenho visual (identidade mantida).
+
+## Critérios de aceite
+
+- Contrastes da tabela ≥4.5:1 (texto) / ≥3:1 (UI) nos dois temas.
+- Nenhum console error no dev server (base-ui nativeButton, CSP worker).
+- Suites verdes: vitest + e2e (count atual: 180 unit / 35 e2e, cresce a cada issue).
+- 4 PRs fechando 4 issues; zero issues abertas ao final.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -44,6 +44,8 @@
   --gave: #f87171;
   --warn: #fbbf24;
   --flow: #22d3ee;
+  --todo: #94a3b8;
+  --violet: #a78bfa;
   --bg: #0a0d12;
   --panel: #0f141b;
   --panel-2: #151c26;
@@ -54,8 +56,8 @@
   --hover: oklch(0.16 0.005 240 / 0.5);
   --text: #c6d0dd;
   --muted-text: #8b98a9;
-  --dim: rgba(198, 208, 221, 0.38);
-  --dimmer: rgba(198, 208, 221, 0.26);
+  --dim: #7d8a9c;
+  --dimmer: #707c8c;
   --background: var(--bg);
   --foreground: var(--text);
   --card: var(--panel);
@@ -79,6 +81,12 @@
 
 html.light {
   color-scheme: light;
+  --fired: #047857;
+  --gave: #b91c1c;
+  --warn: #b45309;
+  --flow: #0e7490;
+  --todo: #475569;
+  --violet: #7c3aed;
   --bg: #f2f4f7;
   --panel: #ffffff;
   --panel-2: #ffffff;
@@ -89,8 +97,8 @@ html.light {
   --hover: rgba(15, 23, 42, 0.05);
   --text: #272c33;
   --muted-text: #5b6572;
-  --dim: rgba(39, 44, 51, 0.45);
-  --dimmer: rgba(39, 44, 51, 0.3);
+  --dim: #5b6572;
+  --dimmer: #64707f;
 }
 
 html {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -195,7 +195,7 @@ export default function Home() {
         <button
           type="button"
           onClick={() => setConfirmClearOpen(true)}
-          className="text-[11px] text-[var(--dimmer)] underline underline-offset-2 hover:text-red-400 cursor-pointer"
+          className="text-[11px] text-[var(--dimmer)] underline underline-offset-2 hover:text-[var(--gave)] cursor-pointer"
           title="remove todos os projetos deste navegador"
         >
           apagar todos os dados
@@ -228,9 +228,8 @@ export default function Home() {
               </Button>
               <Button
                 type="button"
-                variant="default"
+                variant="destructive"
                 size="sm"
-                className="bg-red-500 hover:bg-red-600"
                 onClick={() => {
                   reset();
                   setConfirmClearOpen(false);
@@ -261,7 +260,7 @@ export default function Home() {
       <PrivacyNotice />
 
       {toast && (
-        <div className="fixed bottom-5 left-1/2 -translate-x-1/2 z-50 bg-[var(--panel-3)] border border-zinc-600 text-[var(--text)] text-xs px-4 py-2 rounded-md shadow-lg">
+        <div className="fixed bottom-5 left-1/2 -translate-x-1/2 z-50 bg-[var(--panel-3)] border border-[var(--line)] text-[var(--text)] text-xs px-4 py-2 rounded-md shadow-lg">
           {toast}
         </div>
       )}

--- a/src/components/client/FilterChips.tsx
+++ b/src/components/client/FilterChips.tsx
@@ -10,11 +10,11 @@ export interface ChipDef {
 }
 
 const CHIPS: ChipDef[] = [
-  { key: "todo", label: "todo", cls: "text-slate-400" },
-  { key: "doing", label: "doing", cls: "text-cyan-400" },
-  { key: "waiting", label: "waiting", cls: "text-amber-400" },
-  { key: "done", label: "done", cls: "text-emerald-400" },
-  { key: "blocked", label: "bloq", cls: "text-red-400" },
+  { key: "todo", label: "todo", cls: "text-[var(--todo)]" },
+  { key: "doing", label: "doing", cls: "text-[var(--flow)]" },
+  { key: "waiting", label: "waiting", cls: "text-[var(--warn)]" },
+  { key: "done", label: "done", cls: "text-[var(--fired)]" },
+  { key: "blocked", label: "bloq", cls: "text-[var(--gave)]" },
 ];
 
 interface FilterChipsProps {
@@ -68,7 +68,7 @@ export function FilterChips({
         onClick={onToggleArchived}
         title="mostrar/ocultar projetos arquivados"
         aria-pressed={archivedActive}
-        className={`text-violet-400 ${archivedActive ? "border-current bg-[var(--hover)]" : "opacity-60"}`}
+        className={`text-[var(--violet)] ${archivedActive ? "border-current bg-[var(--hover)]" : "opacity-60"}`}
       >
         arquivados
         <span className="opacity-60">{archivedCount}</span>

--- a/src/components/client/PrivacyNotice.tsx
+++ b/src/components/client/PrivacyNotice.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 
 const NOTICE_KEY = "opsboard.notice-v1";
 
@@ -34,9 +34,12 @@ export function PrivacyNotice() {
         tudo pelos controles do quadro. Veja a política completa na página de privacidade.
       </p>
       <div className="mt-3 flex items-center justify-end gap-2">
-        <Button type="button" variant="ghost" size="xs" render={<Link href="/privacidade" />}>
+        <Link
+          href="/privacidade"
+          className={buttonVariants({ variant: "ghost", size: "xs" }) + " text-[var(--muted-text)]"}
+        >
           política completa
-        </Button>
+        </Link>
         <Button type="button" variant="default" size="sm" onClick={dismiss}>
           entendi
         </Button>

--- a/src/components/client/Stats.tsx
+++ b/src/components/client/Stats.tsx
@@ -28,16 +28,16 @@ export function Stats({ stats, filters, onTogglePrioSort }: StatsProps) {
       </span>
       <span>
         <span className="text-[var(--dimmer)]">pendentes</span>{" "}
-        <span data-testid="stat-pending" className="text-amber-400">{pendentes}</span>
+        <span data-testid="stat-pending" className="text-[var(--warn)]">{pendentes}</span>
       </span>
       <span>
         <span className="text-[var(--dimmer)]">concluídas</span>{" "}
-        <span data-testid="stat-done" className="text-emerald-400">{done}</span>{" "}
+        <span data-testid="stat-done" className="text-[var(--fired)]">{done}</span>{" "}
         <span className="text-[var(--dimmer)]">({pct}%)</span>
       </span>
       <span>
         <span className="text-[var(--dimmer)]">hoje</span>{" "}
-        <span data-testid="stat-today" className="text-emerald-400">+{doneToday}</span>
+        <span data-testid="stat-today" className="text-[var(--fired)]">+{doneToday}</span>
       </span>
       <Tooltip>
         <TooltipTrigger
@@ -47,7 +47,7 @@ export function Stats({ stats, filters, onTogglePrioSort }: StatsProps) {
               variant={filters.prioSort ? "outline" : "ghost"}
               size="xs"
               onClick={onTogglePrioSort}
-              className={`text-[var(--muted-text)] ${filters.prioSort ? "border-current text-amber-400 bg-[var(--hover)]" : ""}`}
+              className={`text-[var(--muted-text)] ${filters.prioSort ? "border-current text-[var(--warn)] bg-[var(--hover)]" : ""}`}
             >
               ↕ prio
             </Button>

--- a/src/components/client/Topbar.tsx
+++ b/src/components/client/Topbar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useMounted } from "@/hooks/useMounted";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { View } from "@/lib/filter";
@@ -56,7 +56,7 @@ export function Topbar({
       <div className="mx-auto max-w-5xl px-4 py-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-6">
         <div className="flex items-center justify-between gap-4">
           <h1 className="text-sm font-bold tracking-tight text-[var(--text)]">
-            ops<span className="text-emerald-400">/</span>board
+            ops<span className="text-[var(--fired)]">/</span>board
           </h1>
           <div className="flex items-center gap-1.5">
             <Tooltip>
@@ -105,16 +105,13 @@ export function Topbar({
             >
               ↑importar
             </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="xs"
-              render={<Link href="/privacidade" />}
-              className="text-[var(--muted-text)] hover:text-[var(--text)]"
+            <Link
+              href="/privacidade"
+              className={buttonVariants({ variant: "ghost", size: "xs" }) + " text-[var(--muted-text)] hover:text-[var(--text)]"}
               title="política de privacidade"
             >
               privacidade
-            </Button>
+            </Link>
             <Button type="button" variant="default" size="sm" onClick={onNewProject}>
               <span className="mr-1">+</span>projeto
             </Button>
@@ -123,7 +120,7 @@ export function Topbar({
 
         <div className="flex-1 min-w-0">
           <label className="block relative flex items-center gap-2">
-            <span className="text-emerald-400 font-bold text-xs" aria-hidden>
+            <span className="text-[var(--fired)] font-bold text-xs" aria-hidden>
               &gt;
             </span>
             <Input

--- a/src/components/client/board/Board.tsx
+++ b/src/components/client/board/Board.tsx
@@ -102,7 +102,7 @@ export function Board({ projetos, filters, onNewProject, projectActions, section
         <button
           type="button"
           onClick={onNewProject}
-          className="rounded-md bg-emerald-400 px-3 py-1.5 text-xs font-bold text-[#0a0d12]"
+          className="rounded-md bg-[var(--fired)] px-3 py-1.5 text-xs font-bold text-primary-foreground"
         >
           + criar primeiro projeto
         </button>

--- a/src/components/client/board/ProjectCard.tsx
+++ b/src/components/client/board/ProjectCard.tsx
@@ -55,15 +55,15 @@ export function ProjectCard({ project, collectActions, onAddSection, onRename, o
   return (
     <section className="rounded-lg border border-[var(--line)] bg-[var(--panel)]">
       <div className="flex items-center gap-2 border-b border-[var(--line)] px-3.5 py-2.5">
-        <span className="font-bold text-emerald-400">##</span>
+        <span className="font-bold text-[var(--fired)]">##</span>
         <h2 className="break-words text-[13px] font-bold tracking-wide text-[var(--text)]">{project.title}</h2>
         {project.blocked && (
-          <Badge variant="destructive" className="rounded-[4px] px-1.5 text-[10px] font-bold uppercase tracking-[0.08em]">
+          <Badge variant="destructive" className="rounded-[4px] px-1.5 text-[11px] font-bold uppercase tracking-[0.08em]">
             stuck
           </Badge>
         )}
         {project.archived && (
-          <Badge variant="outline" className="rounded-[4px] px-1.5 text-[10px] font-bold uppercase tracking-[0.08em]">
+          <Badge variant="outline" className="rounded-[4px] px-1.5 text-[11px] font-bold uppercase tracking-[0.08em]">
             arquivado
           </Badge>
         )}

--- a/src/components/client/board/Section.tsx
+++ b/src/components/client/board/Section.tsx
@@ -140,7 +140,7 @@ export function Section({ projectId, section, onToggleSection, onAddTask, onRena
           )}
           <div
             ref={setDropRef}
-            className={`flex flex-col gap-0.5 rounded-md ${isOver ? "outline outline-1 outline-emerald-400/50" : ""}`}
+            className={`flex flex-col gap-0.5 rounded-md ${isOver ? "outline outline-1 outline-[var(--fired)]/50" : ""}`}
           >
             {sortTasks(section.tasks, !!prioSort, (t) => t.prio).map((t) => (
               <SortableTaskItem
@@ -155,7 +155,7 @@ export function Section({ projectId, section, onToggleSection, onAddTask, onRena
             ))}
           </div>
           <div className="flex items-center gap-2 px-2 pt-2">
-            <span className="text-emerald-400 font-bold text-xs" aria-hidden>
+            <span className="text-[var(--fired)] font-bold text-xs" aria-hidden>
               &gt;
             </span>
             <Input

--- a/src/components/client/board/TaskRow.tsx
+++ b/src/components/client/board/TaskRow.tsx
@@ -25,16 +25,16 @@ export interface TaskRowProps {
 export const NEXT_PRIO: Record<Prio, Prio> = { 1: 2, 2: 3, 3: 1 };
 
 const LED: Record<Status, string> = {
-  todo: "bg-slate-500",
-  doing: "bg-cyan-400",
-  waiting: "bg-amber-400",
-  done: "bg-emerald-400",
+  todo: "bg-[var(--todo)]",
+  doing: "bg-[var(--flow)]",
+  waiting: "bg-[var(--warn)]",
+  done: "bg-[var(--fired)]",
 };
 
 const PRIO_CLS: Record<Prio, string> = {
-  1: "text-red-400 border-red-500/40 bg-red-500/10",
-  2: "text-amber-400 border-amber-500/40 bg-amber-500/10",
-  3: "text-[var(--muted-text)] border-zinc-600",
+  1: "text-[var(--gave)] border-[var(--gave)]/40 bg-[var(--gave)]/10",
+  2: "text-[var(--warn)] border-[var(--warn)]/40 bg-[var(--warn)]/10",
+  3: "text-[var(--muted-text)] border-[var(--line)]",
 };
 
 export function TaskRow({ task, onToggle, onPrioCycle, onStatusChange, onEdit, onDelete }: TaskRowProps) {
@@ -45,18 +45,22 @@ export function TaskRow({ task, onToggle, onPrioCycle, onStatusChange, onEdit, o
   return (
     <div
       data-testid="task-row"
-      className={`flex items-center gap-2.5 rounded-md px-2 py-1.5 transition-colors hover:bg-[var(--hover)] ${done ? "" : ""}`}
+      className={`group flex items-center gap-2.5 rounded-md px-2 py-1.5 transition-colors hover:bg-[var(--hover)] ${done ? "" : ""}`}
     >
       <button
         type="button"
         onClick={onToggle}
         title="alternar concluída"
         aria-label="alternar concluída"
-        className={`h-2 w-2 shrink-0 rounded-full ${task.blocked ? "bg-red-400" : LED[task.status]} ${done ? "bg-emerald-400" : ""} transition-transform hover:scale-125`}
-      />
-      <span className="min-w-0 flex-1 text-[12.5px] leading-snug break-words text-[var(--text)]">
+        className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full transition-colors hover:bg-[var(--hover)]`}
+      >
         <span
-          className={done ? "text-[var(--dim)] line-through decoration-zinc-700" : ""}
+          className={`h-2 w-2 rounded-full ${task.blocked ? "bg-[var(--gave)]" : LED[task.status]} ${done ? "bg-[var(--fired)]" : ""} transition-transform group-hover:scale-110`}
+        />
+      </button>
+      <span className="min-w-0 flex-1 text-[13px] leading-snug break-words text-[var(--text)]">
+        <span
+          className={done ? "text-[var(--dim)] line-through decoration-[var(--line)]" : ""}
           dangerouslySetInnerHTML={{ __html: linkify(task.text) }}
         />
         {task.note && (
@@ -67,7 +71,7 @@ export function TaskRow({ task, onToggle, onPrioCycle, onStatusChange, onEdit, o
         )}
       </span>
       {task.blocked && (
-        <Badge variant="destructive" className="rounded-[4px] px-1.5 text-[10px] font-bold uppercase tracking-[0.08em]">
+        <Badge variant="destructive" className="rounded-[4px] px-1.5 text-[11px] font-bold uppercase tracking-[0.08em]">
           bloqueada
         </Badge>
       )}
@@ -77,7 +81,7 @@ export function TaskRow({ task, onToggle, onPrioCycle, onStatusChange, onEdit, o
             type="button"
             onClick={onPrioCycle}
             aria-label="prioridade: clique pra mudar"
-            className={`shrink-0 rounded px-1.5 py-0.5 border text-[10px] font-bold ${PRIO_CLS[task.prio]}`}
+            className={`shrink-0 rounded px-1.5 py-0.5 border text-[11px] font-bold ${PRIO_CLS[task.prio]}`}
           >
             {PRIO_KEYS[task.prio]}
           </button>
@@ -88,14 +92,14 @@ export function TaskRow({ task, onToggle, onPrioCycle, onStatusChange, onEdit, o
         (overdue ? (
           <Badge
             variant="destructive"
-            className="rounded-[4px] px-1.5 text-[10px] font-bold uppercase tracking-[0.08em]"
+            className="rounded-[4px] px-1.5 text-[11px] font-bold uppercase tracking-[0.08em]"
             title={`vencimento ${task.due}`}
           >
             {fmtDate(task.due)} vencida
           </Badge>
         ) : (
           <span
-            className={`shrink-0 text-[10.5px] font-semibold ${dueSoon ? "text-amber-400" : "text-[var(--muted-text)]"}`}
+            className={`shrink-0 text-[10.5px] font-semibold ${dueSoon ? "text-[var(--warn)]" : "text-[var(--muted-text)]"}`}
             title={`vencimento ${task.due}`}
           >
             {fmtDate(task.due)}
@@ -109,7 +113,7 @@ export function TaskRow({ task, onToggle, onPrioCycle, onStatusChange, onEdit, o
           size="sm"
           aria-label="status"
           title="mudar status"
-          className="h-7 border-[var(--line)] bg-[var(--field)] px-2 text-[11px] text-[var(--muted-text)] hover:border-zinc-600 hover:text-[var(--text)]"
+          className="h-7 border-[var(--line)] bg-[var(--field)] px-2 text-[11px] text-[var(--muted-text)] hover:border-[var(--muted-text)] hover:text-[var(--text)]"
         >
           <SelectValue />
         </SelectTrigger>

--- a/src/components/client/dnd/Kanban.tsx
+++ b/src/components/client/dnd/Kanban.tsx
@@ -48,7 +48,7 @@ function DroppableCol({ status, items }: { status: Status; items: FlatTask[] }) 
   return (
     <div
       ref={setNodeRef}
-      className={`flex min-w-[200px] flex-1 flex-col rounded-lg border ${isOver ? "border-emerald-400/60" : "border-[var(--line)]"} bg-[var(--panel)]`}
+      className={`flex min-w-[200px] flex-1 flex-col rounded-lg border ${isOver ? "border-[var(--fired)]/60" : "border-[var(--line)]"} bg-[var(--panel)]`}
     >
       <header className="border-b border-[var(--line)] px-3 py-2 text-[11px] font-bold uppercase tracking-wider text-[var(--muted-text)]">
         {STATUS_LABEL[status]} <span className="text-[var(--dimmer)]">{items.length}</span>

--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, extname } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(__dirname, "..", "..");
+const CSS = readFileSync(join(ROOT, "src/app/globals.css"), "utf8");
+
+const STATUS_TOKENS = ["--fired", "--gave", "--warn", "--flow", "--todo", "--violet"];
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      walk(full, acc);
+    } else if (extname(full) === ".tsx") {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+const COMPONENT_FILES = walk(join(ROOT, "src/components")).concat([
+  join(ROOT, "src/app/page.tsx"),
+  join(ROOT, "src/app/layout.tsx"),
+]);
+
+describe("tokens de tema", () => {
+  it("define tokens de status no :root", () => {
+    for (const t of STATUS_TOKENS) {
+      expect(CSS).toMatch(new RegExp(`${t}:\\s*#[0-9a-f]{6}`, "i"));
+    }
+  });
+
+  it("override de luz legível (≥4.5:1) para cada token de status em html.light", () => {
+    const light = CSS.match(/html\.light\s*\{([\s\S]*?)\}/)?.[1] ?? "";
+    expect(light).not.toBe("");
+    for (const t of STATUS_TOKENS) {
+      expect(light, `${t} precisa de override em html.light`).toMatch(
+        new RegExp(`${t}:\\s*#[0-9a-f]{6}`, "i"),
+      );
+    }
+  });
+
+  it("--dim/--dimmer são cores sólidas (sem alpha) nos dois temas", () => {
+    for (const block of [CSS, CSS.match(/html\.light\s*\{([\s\S]*?)\}/)?.[1] ?? ""]) {
+      for (const t of ["--dim", "--dimmer"]) {
+        expect(block).toMatch(new RegExp(`${t}:\\s*#[0-9a-f]{6}`, "i"));
+        expect(block).not.toMatch(new RegExp(`${t}:\\s*rgba?`, "i"));
+      }
+    }
+  });
+});
+
+describe("sem cores cruas em componentes", () => {
+  const banned = /(emerald|cyan|amber|red|slate|violet|zinc)-(400|500|600|700)|#0a0d12|#052e21/;
+
+  it("nenhum arquivo de componente usa classes de cor crua", () => {
+    const offenders: string[] = [];
+    for (const file of COMPONENT_FILES) {
+      const src = readFileSync(file, "utf8");
+      if (banned.test(src)) offenders.push(file);
+    }
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
# UX/UI A — fundação visual, tokens e acessibilidade

Close #62

## O que mudou

### Tokens de status (globals.css) — única fonte de verdade
- Novos tokens: `--todo` (slate-300 dark) e `--violet` (violet-300 dark) para o chip "arquivados" — antes o violeta estava hardcoded no componente.
- Overrides no tema claro (`html.light`) com contraste WCAG ≥ 4.5:1 sobre o fundo claro:
  - `--fired #047857` (4.98:1), `--flow #0e7490` (4.86), `--warn #b45309` (4.56), `--gave #b91c1c` (5.87), `--todo #475569` (6.88), `--violet #7c3aed` (5.17)
- `--dim`/`--dimmer` agora são cores sólidas por tema (dark `#7d8a9c`/`#707c8c` 5.55/4.59; light `#5b6572`/`#64707f` 5.37/4.57) — o footer é interativo e precisa manter contraste.

### Guarda de regressão (TDD)
- `src/lib/theme.test.ts` (4 testes): valida que os tokens existem em `:root` e `html.light`, que dim/dimmer são sólidos por tema e que **nenhum componente usa cor crua** (`text-cyan-*`, `bg-red-*`, etc.) — cores só via tokens.

### Componentes migrados para tokens
- FilterChips (cores de status + violet), Stats (warn/fired), Topbar, Board CTA (`bg-[var(--fired)]`), ProjectCard (badges 11px), Section, Kanban, page.tsx.
- Wipe-all "apagar tudo" usa `variant="destructive"` (token `--gave`) no lugar de `bg-red-500` (3.93:1).

### Acessibilidade / correções reais
- **Links de privacidade**: `Button render={<Link/>}` com `nativeButton={false}` gerava `role="button"` no anchor (perde semântica de link — o e2e pegou). Troquei por `<Link>` direto + `buttonVariants` no Topbar e PrivacyNotice. Console limpo em produção (validado por e2e de CSP/XSS).
- TaskRow: LED agora é `<button aria-label>` real de 24px de área de toque, texto de tarefa 13px, cores de prioridade/vencimento via tokens.

## Verificação
- 184 unit (23 arquivos) + 35 e2e + typecheck passando.
