### PR TITLE
UX/UI B — prevenção de perda de dados: undo + confirmação de import

### DIFF
--- a/e2e/crud.spec.ts
+++ b/e2e/crud.spec.ts
@@ -64,7 +64,7 @@ test("adiciona seção extra, edita tarefa: texto, prioridade, vencimento, nota 
   await expect(page.getByRole("button", { name: "bloq 1" })).toBeVisible();
 });
 
-test("exclui tarefa, seção e projeto (com confirmação)", async ({ page }) => {
+test("exclui tarefa, seção e projeto (sem confirm nativo, undo cobre)", async ({ page }) => {
   await page.goto("/");
   await createProject(page, "app");
   await addTask(page, "tarefa a");
@@ -76,7 +76,6 @@ test("exclui tarefa, seção e projeto (com confirmação)", async ({ page }) =>
   await page.getByRole("menuitem", { name: "excluir seção" }).click();
   await expect(page.getByText("geral", { exact: true })).toHaveCount(0);
 
-  page.once("dialog", (dialog) => void dialog.accept());
   await page.getByRole("button", { name: "ações do projeto", exact: true }).click();
   await page.getByRole("menuitem", { name: "excluir projeto" }).click();
   await expect(page.getByText("nenhum projeto na fila.")).toBeVisible();

--- a/e2e/data-protection.spec.ts
+++ b/e2e/data-protection.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function createProject(page: Page, title: string) {
+  const empty = page.getByRole("button", { name: "+ criar primeiro projeto" });
+  if (await empty.isVisible()) {
+    await empty.click();
+  } else {
+    await page.getByRole("button", { name: "+ projeto" }).click();
+  }
+  await page.getByLabel("título").fill(title);
+  await page.getByRole("button", { name: "criar" }).click();
+}
+
+async function addTask(page: Page, text: string) {
+  await page.getByLabel("nova tarefa").first().fill(text);
+  await page.getByLabel("nova tarefa").first().press("Enter");
+}
+
+test("ctrl+z desfaz exclusão de projeto", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "tarefa a");
+
+  await page.getByRole("button", { name: "ações do projeto", exact: true }).click();
+  await page.getByRole("menuitem", { name: "excluir projeto" }).click();
+  await expect(page.getByText("nenhum projeto na fila.")).toBeVisible();
+
+  await page.keyboard.press("Control+z");
+  await expect(page.getByRole("heading", { name: "app" })).toBeVisible();
+  await expect(page.getByText("tarefa a", { exact: false })).toBeVisible();
+  await expect(page.getByText("desfeito", { exact: true })).toBeVisible();
+});
+
+test("ctrl+z não desfaz enquanto digitando em input", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "tarefa a");
+
+  await page.getByLabel("nova tarefa").first().focus();
+  await page.keyboard.press("Control+z");
+  await expect(page.getByRole("heading", { name: "app" })).toBeVisible();
+});
+
+test("import pede confirmação; cancelar não muda nada", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+
+  await page.getByRole("button", { name: "↑importar" }).click();
+  const dialog = page.getByRole("dialog", { name: "importar backup" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText(/substitui 1 projeto/)).toBeVisible();
+  await dialog.getByRole("button", { name: "cancelar" }).click();
+  await expect(dialog).toHaveCount(0);
+  await expect(page.getByRole("heading", { name: "app" })).toBeVisible();
+});
+
+test("ctrl+z desfaz import", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+
+  const backup = {
+    projetos: [
+      { id: "x1", title: "importado", blocked: false, archived: false, sections: [{ id: "sx", title: "geral", notes: "", collapsed: false, tasks: [] }] },
+    ],
+  };
+  await page.getByRole("button", { name: "↑importar" }).click();
+  const chooserPromise = page.waitForEvent("filechooser");
+  await page.getByRole("button", { name: "escolher arquivo" }).click();
+  const chooser = await chooserPromise;
+  await chooser.setFiles({ name: "b.json", mimeType: "application/json", buffer: Buffer.from(JSON.stringify(backup)) });
+  await expect(page.getByText("importado: 1 projeto(s)")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "importado" })).toBeVisible();
+
+  await page.keyboard.press("Control+z");
+  await expect(page.getByRole("heading", { name: "app" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "importado" })).toHaveCount(0);
+});
+
+test("ctrl+z desfaz apagar todos os dados", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "tarefa a");
+
+  await page.getByRole("button", { name: "apagar todos os dados" }).click();
+  const dialog = page.getByRole("dialog", { name: "apagar todos os dados" });
+  await expect(dialog.getByText(/pode desfazer com Ctrl\+Z/)).toBeVisible();
+  await dialog.getByRole("button", { name: "apagar tudo" }).click();
+  await expect(page.getByText("nenhum projeto na fila.")).toBeVisible();
+
+  await page.keyboard.press("Control+z");
+  await expect(page.getByRole("heading", { name: "app" })).toBeVisible();
+  await expect(page.getByText("tarefa a", { exact: false })).toBeVisible();
+});
+
+test("ctrl+z desfaz conclusão de tarefa", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "tarefa a");
+
+  await page.getByTestId("task-row").getByRole("button", { name: "alternar concluída" }).click();
+  await page.keyboard.press("Control+z");
+  await expect(page.getByText("tarefa a", { exact: false })).toBeVisible();
+});

--- a/e2e/export-import.spec.ts
+++ b/e2e/export-import.spec.ts
@@ -17,6 +17,15 @@ async function addTask(page: Page, text: string) {
   await page.getByLabel("nova tarefa").first().press("Enter");
 }
 
+async function importFile(page: Page, name: string, buffer: Buffer) {
+  await page.getByRole("button", { name: "↑importar" }).click();
+  await expect(page.getByRole("dialog", { name: "importar backup" })).toBeVisible();
+  const chooserPromise = page.waitForEvent("filechooser");
+  await page.getByRole("button", { name: "escolher arquivo" }).click();
+  const chooser = await chooserPromise;
+  await chooser.setFiles({ name, mimeType: "application/json", buffer });
+}
+
 const SEED = {
   projetos: [
     {
@@ -68,11 +77,7 @@ test("exporta JSON válido com o estado atual", async ({ page }) => {
 
 test("importa backup e restaura o estado", async ({ page }) => {
   await page.goto("/");
-  await page.locator('input[type="file"]').setInputFiles({
-    name: "backup.json",
-    mimeType: "application/json",
-    buffer: Buffer.from(JSON.stringify(SEED)),
-  });
+  await importFile(page, "backup.json", Buffer.from(JSON.stringify(SEED)));
 
   await expect(page.getByText("importado: 2 projeto(s)")).toBeVisible();
   await expect(page.getByRole("heading", { name: "alpha" })).toBeVisible();
@@ -82,11 +87,7 @@ test("importa backup e restaura o estado", async ({ page }) => {
 
 test("import de arquivo corrompido mostra erro e não muda nada", async ({ page }) => {
   await page.goto("/");
-  await page.locator('input[type="file"]').setInputFiles({
-    name: "quebrado.json",
-    mimeType: "application/json",
-    buffer: Buffer.from("{isso não é json"),
-  });
+  await importFile(page, "quebrado.json", Buffer.from("{isso não é json"));
 
   await expect(page.getByText("arquivo em formato inválido")).toBeVisible();
   await expect(page.getByText("nenhum projeto na fila.")).toBeVisible();
@@ -112,11 +113,7 @@ test("import de JSON válido com estrutura inválida mostra erro claro", async (
       },
     ],
   };
-  await page.locator('input[type="file"]').setInputFiles({
-    name: "injetado.json",
-    mimeType: "application/json",
-    buffer: Buffer.from(JSON.stringify(injetado)),
-  });
+  await importFile(page, "injetado.json", Buffer.from(JSON.stringify(injetado)));
 
   await expect(page.getByText("dados inválidos: estrutura de projeto, seção ou tarefa incorreta")).toBeVisible();
   await expect(page.getByText("nenhum projeto na fila.")).toBeVisible();
@@ -125,11 +122,7 @@ test("import de JSON válido com estrutura inválida mostra erro claro", async (
 test("import de arquivo gigante é rejeitado sem quebrar o estado", async ({ page }) => {
   await page.goto("/");
   const gigante = JSON.stringify({ projetos: [] }).padEnd(2 * 1024 * 1024 + 1, " ");
-  await page.locator('input[type="file"]').setInputFiles({
-    name: "gigante.json",
-    mimeType: "application/json",
-    buffer: Buffer.from(gigante),
-  });
+  await importFile(page, "gigante.json", Buffer.from(gigante));
 
   await expect(page.getByText("arquivo muito grande (máx. 2 MB)")).toBeVisible();
   await expect(page.getByText("nenhum projeto na fila.")).toBeVisible();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,7 +38,10 @@ export default function Home() {
   const moveTask = useBoard((s) => s.moveTask);
   const importState = useBoard((s) => s.importState);
   const reset = useBoard((s) => s.reset);
+  const undo = useBoard((s) => s.undo);
+  const canUndo = useBoard((s) => s.canUndo);
   const [confirmClearOpen, setConfirmClearOpen] = useState(false);
+  const [confirmImportOpen, setConfirmImportOpen] = useState(false);
   const { filters, setQuery, toggleStatus, togglePrioSort, toggleView, toggleArchived, clear } = useFilters();
   const { resolvedTheme, setTheme } = useTheme();
   const isDark = resolvedTheme !== "light";
@@ -102,6 +105,12 @@ export default function Home() {
     [importState],
   );
 
+  const handleUndo = useCallback(() => {
+    if (!canUndo) return;
+    undo();
+    showToast("desfeito");
+  }, [canUndo, undo, showToast]);
+
   useShortcuts(
     {
       onNewProject: () => setNewProjectOpen(true),
@@ -112,6 +121,7 @@ export default function Home() {
       onClearFilters: clear,
       onFocusAdd: () => {},
       onFilterStatus: toggleStatus,
+      onUndo: handleUndo,
     },
     { isModalOpen: () => newProjectOpen },
   );
@@ -131,7 +141,7 @@ export default function Home() {
         onToggleTheme={toggleTheme}
         onNewProject={() => setNewProjectOpen(true)}
         onExport={handleExport}
-        onImport={() => fileRef.current?.click()}
+        onImport={() => setConfirmImportOpen(true)}
       />
       <input
         ref={fileRef}
@@ -220,7 +230,7 @@ export default function Home() {
             </div>
             <div className="px-4 py-4 text-xs leading-relaxed text-[var(--muted-text)]">
               Isso remove {projetos.length} projeto(s) deste navegador. Considere exportar um backup antes.
-              Esta ação não pode ser desfeita.
+              Você pode desfazer com Ctrl+Z.
             </div>
             <div className="flex justify-end gap-2 px-4 pb-4">
               <Button type="button" variant="ghost" size="xs" onClick={() => setConfirmClearOpen(false)}>
@@ -237,6 +247,46 @@ export default function Home() {
                 }}
               >
                 apagar tudo
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {confirmImportOpen && (
+        <Dialog open onOpenChange={(o) => { if (!o) setConfirmImportOpen(false); }}>
+          <DialogContent
+            showCloseButton={false}
+            className="!sm:max-w-[380px] gap-0 rounded-lg border border-[var(--line-soft)] bg-[var(--panel-2)] p-0 text-[var(--text)] shadow-xl"
+          >
+            <div className="flex items-center justify-between border-b border-[var(--line)] px-4 py-3">
+              <DialogTitle className="text-[13px] font-bold text-[var(--text)]">importar backup</DialogTitle>
+              <DialogClose
+                render={
+                  <Button type="button" variant="ghost" size="icon-xs" title="fechar" aria-label="fechar">
+                    ×
+                  </Button>
+                }
+              />
+            </div>
+            <div className="px-4 py-4 text-xs leading-relaxed text-[var(--muted-text)]">
+              Importar substitui {projetos.length} projeto(s) atual(is). Exporte um backup antes se quiser
+              preservá-los. Você pode desfazer com Ctrl+Z.
+            </div>
+            <div className="flex justify-end gap-2 px-4 pb-4">
+              <Button type="button" variant="ghost" size="xs" onClick={() => setConfirmImportOpen(false)}>
+                cancelar
+              </Button>
+              <Button
+                type="button"
+                variant="default"
+                size="sm"
+                onClick={() => {
+                  setConfirmImportOpen(false);
+                  fileRef.current?.click();
+                }}
+              >
+                escolher arquivo
               </Button>
             </div>
           </DialogContent>

--- a/src/components/client/board/ProjectCard.test.tsx
+++ b/src/components/client/board/ProjectCard.test.tsx
@@ -73,24 +73,14 @@ describe("ProjectCard", () => {
     expect(p.onRename).toHaveBeenCalledWith("p1", "Renomeado", false);
   });
 
-  it("exclui após confirmação", async () => {
+  it("exclui diretamente sem confirm nativo (undo cobre)", async () => {
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     const p = base();
     render(<ProjectCard {...p} />);
     await openMenu();
     await userEvent.click(await screen.findByRole("menuitem", { name: "excluir projeto" }));
-    expect(confirmSpy).toHaveBeenCalled();
+    expect(confirmSpy).not.toHaveBeenCalled();
     expect(p.onDelete).toHaveBeenCalledWith("p1");
-    confirmSpy.mockRestore();
-  });
-
-  it("não exclui sem confirmação", async () => {
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
-    const p = base();
-    render(<ProjectCard {...p} />);
-    await openMenu();
-    await userEvent.click(await screen.findByRole("menuitem", { name: "excluir projeto" }));
-    expect(p.onDelete).not.toHaveBeenCalled();
     confirmSpy.mockRestore();
   });
 

--- a/src/components/client/board/ProjectCard.tsx
+++ b/src/components/client/board/ProjectCard.tsx
@@ -102,9 +102,7 @@ export function ProjectCard({ project, collectActions, onAddSection, onRename, o
               <DropdownMenuItem
                 variant="destructive"
                 className="text-xs"
-                onClick={() => {
-                  if (window.confirm(`excluir projeto "${project.title}"?`)) onDelete(project.id);
-                }}
+                onClick={() => onDelete(project.id)}
               >
                 excluir projeto
               </DropdownMenuItem>

--- a/src/hooks/useShortcuts.test.tsx
+++ b/src/hooks/useShortcuts.test.tsx
@@ -11,6 +11,7 @@ const handlers = () => ({
   onClearFilters: vi.fn(),
   onFocusAdd: vi.fn(),
   onFilterStatus: vi.fn(),
+  onUndo: vi.fn(),
 });
 
 const press = (key: string) => {
@@ -97,6 +98,31 @@ describe("useShortcuts", () => {
     fireEvent.keyDown(window, { key: "p", metaKey: true });
     fireEvent.keyDown(window, { key: "p", altKey: true });
     expect(h.onNewProject).not.toHaveBeenCalled();
+  });
+
+  it("ctrl+z dispara undo", () => {
+    const h = handlers();
+    renderHook(() => useShortcuts(h));
+    fireEvent.keyDown(window, { key: "z", ctrlKey: true });
+    expect(h.onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it("meta+z (mac) dispara undo", () => {
+    const h = handlers();
+    renderHook(() => useShortcuts(h));
+    fireEvent.keyDown(window, { key: "z", metaKey: true });
+    expect(h.onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it("ctrl+z não dispara undo quando digitando em input", () => {
+    const h = handlers();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    renderHook(() => useShortcuts(h));
+    fireEvent.keyDown(window, { key: "z", ctrlKey: true });
+    expect(h.onUndo).not.toHaveBeenCalled();
+    input.remove();
   });
 
   it("remove listener ao desmontar", () => {

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -9,6 +9,7 @@ export interface ShortcutHandlers {
   onClearFilters: () => void;
   onFocusAdd: () => void;
   onFilterStatus: (status: StatusFilter) => void;
+  onUndo: () => void;
 }
 
 const STATUS_KEYS: StatusFilter[] = ["todo", "doing", "waiting", "done", "blocked"];
@@ -24,6 +25,11 @@ export function useShortcuts(h: ShortcutHandlers, opts?: { isModalOpen?: () => b
 
       const modalOpen = opts?.isModalOpen?.() ?? false;
 
+      if ((e.ctrlKey || e.metaKey) && !e.altKey && e.key.toLowerCase() === "z") {
+        e.preventDefault();
+        h.onUndo();
+        return;
+      }
       if (e.key === "Escape" && !modalOpen) {
         h.onClearFilters();
         return;

--- a/src/lib/store.test.ts
+++ b/src/lib/store.test.ts
@@ -156,6 +156,158 @@ describe("board store", () => {
     store.getState().toggleProjectArchive(pid);
     expect(store.getState().projetos[0].archived).toBe(false);
   });
+
+  it("canUndo começa false", () => {
+    expect(store.getState().canUndo).toBe(false);
+  });
+
+  it("deleteTask é desfeita restaurando a tarefa", () => {
+    store.getState().deleteTask("p1", "s1", "t1");
+    expect(store.getState().projetos[0].sections[0].tasks.map((t) => t.id)).toEqual(["t2"]);
+    expect(store.getState().canUndo).toBe(true);
+
+    store.getState().undo();
+    const t = store.getState().projetos[0].sections[0].tasks[0];
+    expect(t.id).toBe("t1");
+    expect(t.text).toBe("tarefa 1");
+    expect(store.getState().canUndo).toBe(false);
+  });
+
+  it("addProject é desfeito removendo o projeto", () => {
+    store.getState().addProject("Novo");
+    expect(store.getState().projetos).toHaveLength(2);
+    store.getState().undo();
+    expect(store.getState().projetos).toHaveLength(1);
+    expect(store.getState().projetos[0].id).toBe("p1");
+  });
+
+  it("addSection e addTask são desfeitas", () => {
+    store.getState().addSection("p1", "dev");
+    store.getState().addTask("p1", "s1", "nova");
+    store.getState().undo();
+    expect(store.getState().projetos[0].sections[0].tasks.map((t) => t.text)).toEqual(["tarefa 1", "tarefa 2"]);
+    store.getState().undo();
+    expect(store.getState().projetos[0].sections.map((s) => s.title)).toEqual(["geral"]);
+  });
+
+  it("renameProject é desfeita restaurando título e bloqueio", () => {
+    store.getState().renameProject("p1", "Renomeado", true);
+    store.getState().undo();
+    const p = store.getState().projetos[0];
+    expect(p.title).toBe("Projeto A");
+    expect(p.blocked).toBe(false);
+  });
+
+  it("editTask é desfeita restaurando campos", () => {
+    store.getState().editTask("p1", "s1", "t1", { note: "nota", prio: 1, due: "2026-02-01", blocked: true });
+    store.getState().undo();
+    const t = store.getState().projetos[0].sections[0].tasks[0];
+    expect(t.note).toBe("");
+    expect(t.prio).toBe(3);
+    expect(t.due).toBe("");
+    expect(t.blocked).toBe(false);
+  });
+
+  it("toggleTask é desfeita", () => {
+    store.getState().toggleTask("p1", "s1", "t1");
+    expect(store.getState().projetos[0].sections[0].tasks[0].status).toBe("done");
+    store.getState().undo();
+    expect(store.getState().projetos[0].sections[0].tasks[0].status).toBe("todo");
+  });
+
+  it("moveTask é desfeita restaurando a ordem", () => {
+    store.setState({
+      projetos: [
+        {
+          ...seedProjeto(),
+          sections: [
+            seedProjeto().sections[0],
+            { id: "s2", title: "outra", notes: "", collapsed: false, tasks: [] },
+          ],
+        },
+      ],
+    });
+    store.getState().moveTask({ pid: "p1", sid: "s1", tid: "t1" }, { pid: "p1", sid: "s2" }, 0);
+    expect(store.getState().projetos[0].sections[1].tasks.map((t) => t.id)).toEqual(["t1"]);
+    store.getState().undo();
+    expect(store.getState().projetos[0].sections[0].tasks.map((t) => t.id)).toEqual(["t1", "t2"]);
+    expect(store.getState().projetos[0].sections[1].tasks).toEqual([]);
+  });
+
+  it("importState é desfeita restaurando os projetos anteriores", () => {
+    const antes = store.getState().projetos;
+    store.getState().importState([{ id: "x", title: "Importado", blocked: false, archived: false, sections: [] }]);
+    store.getState().undo();
+    expect(store.getState().projetos).toEqual(antes);
+  });
+
+  it("reset é desfeita restaurando tudo", () => {
+    store.getState().reset();
+    expect(store.getState().projetos).toEqual([]);
+    store.getState().undo();
+    expect(store.getState().projetos).toHaveLength(1);
+    expect(store.getState().projetos[0].sections[0].tasks).toHaveLength(2);
+  });
+
+  it("toggleProjectArchive é desfeita", () => {
+    store.getState().toggleProjectArchive("p1");
+    expect(store.getState().projetos[0].archived).toBe(true);
+    store.getState().undo();
+    expect(store.getState().projetos[0].archived).toBe(false);
+  });
+
+  it("toggleSection não cria passo de undo (estado de visualização)", () => {
+    store.getState().toggleSection("p1", "s1");
+    expect(store.getState().canUndo).toBe(false);
+  });
+
+  it("undo linear desfaz cada passo mesmo voltando ao mesmo estado", () => {
+    store.getState().toggleTask("p1", "s1", "t1");
+    store.getState().toggleTask("p1", "s1", "t1");
+    expect(store.getState().projetos[0].sections[0].tasks[0].status).toBe("todo");
+    store.getState().undo();
+    expect(store.getState().projetos[0].sections[0].tasks[0].status).toBe("done");
+    expect(store.getState().canUndo).toBe(true);
+    store.getState().undo();
+    expect(store.getState().projetos[0].sections[0].tasks[0].status).toBe("todo");
+    expect(store.getState().canUndo).toBe(false);
+  });
+
+  it("undo vazio não quebra nem altera estado", () => {
+    store.getState().undo();
+    store.getState().undo();
+    expect(store.getState().projetos).toHaveLength(1);
+    expect(store.getState().canUndo).toBe(false);
+  });
+
+  it("undo em sequência desfaz passo a passo", () => {
+    store.getState().addProject("A");
+    store.getState().addProject("B");
+    expect(store.getState().projetos).toHaveLength(3);
+    store.getState().undo();
+    expect(store.getState().projetos).toHaveLength(2);
+    expect(store.getState().canUndo).toBe(true);
+    store.getState().undo();
+    expect(store.getState().projetos).toHaveLength(1);
+    expect(store.getState().canUndo).toBe(false);
+  });
+
+  it("stack limita a 50 passos (os mais recentes)", () => {
+    for (let i = 0; i < 60; i++) store.getState().addProject(`p${i}`);
+    expect(store.getState().projetos).toHaveLength(61);
+    for (let i = 0; i < 55; i++) store.getState().undo();
+    expect(store.getState().canUndo).toBe(false);
+    expect(store.getState().projetos).toHaveLength(11);
+  });
+
+  it("canUndo não é persistido", () => {
+    localStorage.clear();
+    const s = createBoardStore();
+    s.getState().addProject("X");
+    s.getState().undo();
+    const stored = JSON.parse(localStorage.getItem("opsboard.v1")!);
+    expect(stored.state).not.toHaveProperty("canUndo");
+  });
 });
 
 describe("persistência", () => {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -24,6 +24,8 @@ const safeLocalStorage = {
 
 interface BoardStore {
   projetos: Project[];
+  canUndo: boolean;
+  undo: () => void;
   addProject: (title: string) => void;
   renameProject: (id: string, title: string, blocked: boolean) => void;
   deleteProject: (id: string) => void;
@@ -66,200 +68,247 @@ const makeTask = (text: string): Section["tasks"][number] => ({
 });
 
 export function createBoardStore(initial: Project[] = []) {
+  const undoStack: string[] = [];
+  const MAX_UNDO = 50;
   return create<BoardStore>()(
     persist(
-      (set) => ({
+      (set, get) => {
+        const commit = (fn: () => void) => {
+          const prev = JSON.stringify(get().projetos);
+          fn();
+          if (JSON.stringify(get().projetos) !== prev) {
+            undoStack.push(prev);
+            if (undoStack.length > MAX_UNDO) undoStack.shift();
+            set({ canUndo: true });
+          }
+        };
+        return {
         projetos: initial,
+        canUndo: false,
+
+        undo: () => {
+          const snap = undoStack.pop();
+          if (snap === undefined) return;
+          set({ projetos: JSON.parse(snap) as Project[] });
+          set({ canUndo: undoStack.length > 0 });
+        },
 
         addProject: (title) =>
-          set((s) => ({
-            projetos: [
-              ...s.projetos,
-              {
-                id: uid(),
-                title,
-                blocked: false,
-                archived: false,
-                sections: [{ id: uid(), title: "geral", tasks: [], notes: "", collapsed: false }],
-              },
-            ],
-          })),
+          commit(() =>
+            set((s) => ({
+              projetos: [
+                ...s.projetos,
+                {
+                  id: uid(),
+                  title,
+                  blocked: false,
+                  archived: false,
+                  sections: [{ id: uid(), title: "geral", tasks: [], notes: "", collapsed: false }],
+                },
+              ],
+            })),
+          ),
 
         renameProject: (id, title, blocked) =>
-          set((s) => ({
-            projetos: s.projetos.map((p) => (p.id === id ? { ...p, title, blocked } : p)),
-          })),
+          commit(() =>
+            set((s) => ({
+              projetos: s.projetos.map((p) => (p.id === id ? { ...p, title, blocked } : p)),
+            })),
+          ),
 
-        deleteProject: (id) => set((s) => ({ projetos: s.projetos.filter((p) => p.id !== id) })),
+        deleteProject: (id) =>
+          commit(() => set((s) => ({ projetos: s.projetos.filter((p) => p.id !== id) }))),
 
         toggleProjectArchive: (id) =>
-          set((s) => ({
-            projetos: s.projetos.map((p) => (p.id === id ? { ...p, archived: !p.archived } : p)),
-          })),
+          commit(() =>
+            set((s) => ({
+              projetos: s.projetos.map((p) => (p.id === id ? { ...p, archived: !p.archived } : p)),
+            })),
+          ),
 
         addSection: (pid, title) =>
-          set((s) => ({
-            projetos: s.projetos.map((p) =>
-              p.id === pid
-                ? { ...p, sections: [...p.sections, { id: uid(), title, tasks: [], notes: "", collapsed: false }] }
-                : p,
-            ),
-          })),
+          commit(() =>
+            set((s) => ({
+              projetos: s.projetos.map((p) =>
+                p.id === pid
+                  ? { ...p, sections: [...p.sections, { id: uid(), title, tasks: [], notes: "", collapsed: false }] }
+                  : p,
+              ),
+            })),
+          ),
 
         renameSection: (pid, sid, title) =>
-          set((s) => ({
-            projetos: s.projetos.map((p) =>
-              p.id === pid
-                ? { ...p, sections: p.sections.map((sec) => (sec.id === sid ? { ...sec, title } : sec)) }
-                : p,
-            ),
-          })),
+          commit(() =>
+            set((s) => ({
+              projetos: s.projetos.map((p) =>
+                p.id === pid
+                  ? { ...p, sections: p.sections.map((sec) => (sec.id === sid ? { ...sec, title } : sec)) }
+                  : p,
+              ),
+            })),
+          ),
 
         deleteSection: (pid, sid) =>
-          set((s) => ({
-            projetos: s.projetos.map((p) =>
-              p.id === pid ? { ...p, sections: p.sections.filter((sec) => sec.id !== sid) } : p,
-            ),
-          })),
+          commit(() =>
+            set((s) => ({
+              projetos: s.projetos.map((p) =>
+                p.id === pid ? { ...p, sections: p.sections.filter((sec) => sec.id !== sid) } : p,
+              ),
+            })),
+          ),
 
         addTask: (pid, sid, text) =>
-          set((s) => ({
-            projetos: s.projetos.map((p) =>
-              p.id === pid
-                ? {
-                    ...p,
-                    sections: p.sections.map((sec) =>
-                      sec.id === sid ? { ...sec, tasks: [...sec.tasks, makeTask(text.trim())] } : sec,
-                    ),
-                  }
-                : p,
-            ),
-          })),
+          commit(() =>
+            set((s) => ({
+              projetos: s.projetos.map((p) =>
+                p.id === pid
+                  ? {
+                      ...p,
+                      sections: p.sections.map((sec) =>
+                        sec.id === sid ? { ...sec, tasks: [...sec.tasks, makeTask(text.trim())] } : sec,
+                      ),
+                    }
+                  : p,
+              ),
+            })),
+          ),
 
         editTask: (pid, sid, tid, patch) =>
-          set((s) => ({
-            projetos: s.projetos.map((p) =>
-              p.id === pid
-                ? {
-                    ...p,
-                    sections: p.sections.map((sec) =>
-                      sec.id === sid
-                        ? {
-                            ...sec,
-                            tasks: sec.tasks.map((t) =>
-                              t.id === tid
-                                ? {
-                                    ...t,
-                                    text: patch.text ?? t.text,
-                                    note: patch.note ?? t.note,
-                                    blocked: patch.blocked ?? t.blocked,
-                                    prio: patch.prio ?? t.prio,
-                                    due: patch.due ?? t.due,
-                                  }
-                                : t,
-                            ),
-                          }
-                        : sec,
-                    ),
-                  }
-                : p,
-            ),
-          })),
+          commit(() =>
+            set((s) => ({
+              projetos: s.projetos.map((p) =>
+                p.id === pid
+                  ? {
+                      ...p,
+                      sections: p.sections.map((sec) =>
+                        sec.id === sid
+                          ? {
+                              ...sec,
+                              tasks: sec.tasks.map((t) =>
+                                t.id === tid
+                                  ? {
+                                      ...t,
+                                      text: patch.text ?? t.text,
+                                      note: patch.note ?? t.note,
+                                      blocked: patch.blocked ?? t.blocked,
+                                      prio: patch.prio ?? t.prio,
+                                      due: patch.due ?? t.due,
+                                    }
+                                  : t,
+                              ),
+                            }
+                          : sec,
+                      ),
+                    }
+                  : p,
+              ),
+            })),
+          ),
 
         deleteTask: (pid, sid, tid) =>
-          set((s) => ({
-            projetos: s.projetos.map((p) =>
-              p.id === pid
-                ? {
-                    ...p,
-                    sections: p.sections.map((sec) =>
-                      sec.id === sid ? { ...sec, tasks: sec.tasks.filter((t) => t.id !== tid) } : sec,
-                    ),
-                  }
-                : p,
-            ),
-          })),
+          commit(() =>
+            set((s) => ({
+              projetos: s.projetos.map((p) =>
+                p.id === pid
+                  ? {
+                      ...p,
+                      sections: p.sections.map((sec) =>
+                        sec.id === sid ? { ...sec, tasks: sec.tasks.filter((t) => t.id !== tid) } : sec,
+                      ),
+                    }
+                  : p,
+              ),
+            })),
+          ),
 
         setTaskStatus: (pid, sid, tid, status) =>
-          set((s) => {
-            const t = findTask(s.projetos, pid, sid, tid);
-            if (!t) return s;
-            const wasDone = t.status === "done";
-            const doneAt = status === "done" && !wasDone ? new Date().toISOString() : status !== "done" && wasDone ? null : t.doneAt;
-            return {
-              projetos: s.projetos.map((p) =>
-                p.id === pid
-                  ? {
-                      ...p,
-                      sections: p.sections.map((sec) =>
-                        sec.id === sid
-                          ? { ...sec, tasks: sec.tasks.map((x) => (x.id === tid ? { ...x, status, doneAt } : x)) }
-                          : sec,
-                      ),
-                    }
-                  : p,
-              ),
-            };
-          }),
+          commit(() =>
+            set((s) => {
+              const t = findTask(s.projetos, pid, sid, tid);
+              if (!t) return s;
+              const wasDone = t.status === "done";
+              const doneAt = status === "done" && !wasDone ? new Date().toISOString() : status !== "done" && wasDone ? null : t.doneAt;
+              return {
+                projetos: s.projetos.map((p) =>
+                  p.id === pid
+                    ? {
+                        ...p,
+                        sections: p.sections.map((sec) =>
+                          sec.id === sid
+                            ? { ...sec, tasks: sec.tasks.map((x) => (x.id === tid ? { ...x, status, doneAt } : x)) }
+                            : sec,
+                        ),
+                      }
+                    : p,
+                ),
+              };
+            }),
+          ),
 
         setTaskPrio: (pid, sid, tid, prio) =>
-          set((s) => ({
-            projetos: s.projetos.map((p) =>
-              p.id === pid
-                ? {
-                    ...p,
-                    sections: p.sections.map((sec) =>
-                      sec.id === sid
-                        ? { ...sec, tasks: sec.tasks.map((t) => (t.id === tid ? { ...t, prio } : t)) }
-                        : sec,
-                    ),
-                  }
-                : p,
-            ),
-          })),
+          commit(() =>
+            set((s) => ({
+              projetos: s.projetos.map((p) =>
+                p.id === pid
+                  ? {
+                      ...p,
+                      sections: p.sections.map((sec) =>
+                        sec.id === sid
+                          ? { ...sec, tasks: sec.tasks.map((t) => (t.id === tid ? { ...t, prio } : t)) }
+                          : sec,
+                      ),
+                    }
+                  : p,
+              ),
+            })),
+          ),
 
         cycleTaskPrio: (pid, sid, tid) =>
-          set((s) => {
-            const t = findTask(s.projetos, pid, sid, tid);
-            if (!t) return s;
-            const next = (t.prio % 3) + 1 as Prio;
-            return {
-              projetos: s.projetos.map((p) =>
-                p.id === pid
-                  ? {
-                      ...p,
-                      sections: p.sections.map((sec) =>
-                        sec.id === sid
-                          ? { ...sec, tasks: sec.tasks.map((x) => (x.id === tid ? { ...x, prio: next } : x)) }
-                          : sec,
-                      ),
-                    }
-                  : p,
-              ),
-            };
-          }),
+          commit(() =>
+            set((s) => {
+              const t = findTask(s.projetos, pid, sid, tid);
+              if (!t) return s;
+              const next = (t.prio % 3) + 1 as Prio;
+              return {
+                projetos: s.projetos.map((p) =>
+                  p.id === pid
+                    ? {
+                        ...p,
+                        sections: p.sections.map((sec) =>
+                          sec.id === sid
+                            ? { ...sec, tasks: sec.tasks.map((x) => (x.id === tid ? { ...x, prio: next } : x)) }
+                            : sec,
+                        ),
+                      }
+                    : p,
+                ),
+              };
+            }),
+          ),
 
         toggleTask: (pid, sid, tid) =>
-          set((s) => {
-            const t = findTask(s.projetos, pid, sid, tid);
-            if (!t) return s;
-            const status: Status = t.status === "done" ? "todo" : "done";
-            const doneAt = status === "done" ? new Date().toISOString() : null;
-            return {
-              projetos: s.projetos.map((p) =>
-                p.id === pid
-                  ? {
-                      ...p,
-                      sections: p.sections.map((sec) =>
-                        sec.id === sid
-                          ? { ...sec, tasks: sec.tasks.map((x) => (x.id === tid ? { ...x, status, doneAt } : x)) }
-                          : sec,
-                      ),
-                    }
-                  : p,
-              ),
-            };
-          }),
+          commit(() =>
+            set((s) => {
+              const t = findTask(s.projetos, pid, sid, tid);
+              if (!t) return s;
+              const status: Status = t.status === "done" ? "todo" : "done";
+              const doneAt = status === "done" ? new Date().toISOString() : null;
+              return {
+                projetos: s.projetos.map((p) =>
+                  p.id === pid
+                    ? {
+                        ...p,
+                        sections: p.sections.map((sec) =>
+                          sec.id === sid
+                            ? { ...sec, tasks: sec.tasks.map((x) => (x.id === tid ? { ...x, status, doneAt } : x)) }
+                            : sec,
+                        ),
+                      }
+                    : p,
+                ),
+              };
+            }),
+          ),
 
         toggleSection: (pid, sid) =>
           set((s) => ({
@@ -276,48 +325,52 @@ export function createBoardStore(initial: Project[] = []) {
           })),
 
         moveTask: (src, dest, index) =>
-          set((s) => {
-            const srcSec = findSection(s.projetos, src.pid, src.sid);
-            const destSec = findSection(s.projetos, dest.pid, dest.sid);
-            if (!srcSec || !destSec) return s;
-            const task = srcSec.tasks.find((t) => t.id === src.tid);
-            if (!task) return s;
+          commit(() =>
+            set((s) => {
+              const srcSec = findSection(s.projetos, src.pid, src.sid);
+              const destSec = findSection(s.projetos, dest.pid, dest.sid);
+              if (!srcSec || !destSec) return s;
+              const task = srcSec.tasks.find((t) => t.id === src.tid);
+              if (!task) return s;
 
-            const next = s.projetos.map((p) => {
-              const secs = p.sections.map((sec) => {
-                if (sec.id === src.sid) {
-                  return { ...sec, tasks: sec.tasks.filter((t) => t.id !== src.tid) };
-                }
-                return sec;
+              const next = s.projetos.map((p) => {
+                const secs = p.sections.map((sec) => {
+                  if (sec.id === src.sid) {
+                    return { ...sec, tasks: sec.tasks.filter((t) => t.id !== src.tid) };
+                  }
+                  return sec;
+                });
+                return { ...p, sections: secs };
               });
-              return { ...p, sections: secs };
-            });
 
-            const destSecAfter = findSection(next, dest.pid, dest.sid)!;
-            const insertAt = Math.max(0, Math.min(index, destSecAfter.tasks.length));
-            const tasks = [...destSecAfter.tasks];
-            tasks.splice(insertAt, 0, task);
+              const destSecAfter = findSection(next, dest.pid, dest.sid)!;
+              const insertAt = Math.max(0, Math.min(index, destSecAfter.tasks.length));
+              const tasks = [...destSecAfter.tasks];
+              tasks.splice(insertAt, 0, task);
 
-            return {
-              projetos: next.map((p) =>
-                p.id === dest.pid
-                  ? {
-                      ...p,
-                      sections: p.sections.map((sec) => (sec.id === dest.sid ? { ...sec, tasks } : sec)),
-                    }
-                  : p,
-              ),
-            };
-          }),
+              return {
+                projetos: next.map((p) =>
+                  p.id === dest.pid
+                    ? {
+                        ...p,
+                        sections: p.sections.map((sec) => (sec.id === dest.sid ? { ...sec, tasks } : sec)),
+                      }
+                    : p,
+                ),
+              };
+            }),
+          ),
 
-        reset: () => set({ projetos: [] }),
+        reset: () => commit(() => set({ projetos: [] })),
 
-        importState: (projetos) => set({ projetos }),
-      }),
+        importState: (projetos) => commit(() => set({ projetos })),
+      };
+      },
       {
         name: "opsboard.v1",
         version: SCHEMA_VERSION,
         storage: createJSONStorage(() => safeLocalStorage),
+        partialize: (s) => ({ projetos: s.projetos }),
         migrate: (persisted, version) => {
           if (version < SCHEMA_VERSION) {
             const legacy = migrateLegacy(persisted);


### PR DESCRIPTION
# UX/UI B — Prevenção de perda de dados: undo + confirmação de import

Close #64

## O que mudou

### Undo global (Ctrl+Z / ⌘Z)
- **Store** (`src/lib/store.ts`): wrapper `commit` nas 17 mutações de dados (add/rename/delete/move/toggle/import/reset). Antes de cada mutação captura snapshot JSON de `projetos`; push na stack sessão-only com **cap de 50 passos** (descartando os mais antigos).
- `undo()` restaura o snapshot; `canUndo` reativo (limpa ao esvaziar a stack).
- **`toggleSection` não entra no undo** (estado de visualização, não dado).
- `partialize` no persist: `canUndo` **não é persistido** (storage shape inalterado — sem bump de schema).
- **Atalho** (`src/hooks/useShortcuts.ts`): `Ctrl+Z`/`⌘Z` com `preventDefault`, **guard de foco**: não intercepta quando foco está em input/textarea/select/contenteditable (deixa o undo nativo do campo agir).
- Toast "desfeito" ao desfazer (página).

### Import com confirmação
- Botão "↑importar" agora abre dialog: *"Importar substitui N projeto(s) atual(is). Exporte um backup antes se quiser preservá-los. Você pode desfazer com Ctrl+Z."* com **cancelar** / **escolher arquivo**.
- Import continua validado (formato, estrutura, tamanho) e agora é desfazível.

### Delete consistente (sem confirm nativo)
- Removido `window.confirm` do excluir projeto (ProjectCard) — undo cobre.
- Dialog "apagar todos os dados" atualizado: *"Você pode desfazer com Ctrl+Z"* (era "não pode ser desfeita") — reset é desfazível agora.

## Testes (TDD)
- **Unit**: 17 testes novos de undo no store (restauração por ação, sequência, cap 50, no-ops, canUndo não persistido) + 3 testes do atalho (ctrl+z, ⌘z, guard em input). Total **203 pass (23 arquivos)**.
- **E2E**: novo `e2e/data-protection.spec.ts` (6 testes: undo de exclusão/import/wipe-all/conclusão, guard em input, cancelar import) + specs existentes atualizados (crud sem dialog nativo, export-import com dialog de confirmação). Total **41 pass**.
- typecheck limpo.

## Verificação
- 203 unit + 41 e2e verdes; console limpo em produção (CSP/XSS specs passam).
