### PR TITLE
UX/UI C — feedback e ajuda: confete no momento certo, atalho n, modal de ajuda

### DIFF
--- a/e2e/feedback.spec.ts
+++ b/e2e/feedback.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function createProject(page: Page, title: string) {
+  const empty = page.getByRole("button", { name: "+ criar primeiro projeto" });
+  if (await empty.isVisible()) {
+    await empty.click();
+  } else {
+    await page.getByRole("button", { name: "+ projeto" }).click();
+  }
+  await page.getByLabel("título").fill(title);
+  await page.getByRole("button", { name: "criar" }).click();
+}
+
+async function addTask(page: Page, text: string) {
+  await page.getByLabel("nova tarefa").first().fill(text);
+  await page.getByLabel("nova tarefa").first().press("Enter");
+}
+
+test("atalho n foca o primeiro input de nova tarefa", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "tarefa a");
+
+  await page.keyboard.press("n");
+  await expect(page.getByLabel("nova tarefa").first()).toBeFocused();
+});
+
+test("? abre o modal de ajuda com tabela de atalhos e esc fecha", async ({ page }) => {
+  await page.goto("/");
+  await page.keyboard.press("?");
+  const dialog = page.getByRole("dialog", { name: "atalhos e dicas" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("desfazer", { exact: true })).toBeVisible();
+  await expect(dialog.getByText("focar nova tarefa", { exact: true })).toBeVisible();
+  await expect(dialog.getByText("kanban: arraste cartões entre colunas", { exact: false })).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await expect(dialog).toHaveCount(0);
+});
+
+test("concluir tarefa dispara confete (canvas) e toast acessível de backup", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "tarefa a");
+
+  await page.getByTestId("task-row").getByRole("button", { name: "alternar concluída" }).click();
+  await expect.poll(() => page.locator("canvas").count()).toBeGreaterThan(0);
+
+  await page.getByRole("button", { name: "↓exportar" }).click();
+  const toast = page.getByRole("status").filter({ hasText: "backup exportado" });
+  await expect(toast).toBeVisible();
+  await expect(toast).toHaveAttribute("aria-live", "polite");
+});
+
+test("hint da lista descreve arraste entre seções/projetos", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByText(/lista: arraste tarefas entre seções\/projetos/)).toBeVisible();
+});

--- a/e2e/interactions.spec.ts
+++ b/e2e/interactions.spec.ts
@@ -80,7 +80,9 @@ test("atalhos: p abre projeto, 1 filtra todo, ? mostra ajuda, t alterna tema, es
   await expect(page.getByRole("button", { name: "todo 1" })).toHaveAttribute("aria-pressed", "true");
 
   await page.keyboard.press("?");
-  await expect(page.getByText("p projeto · n tarefa · 1-5 filtros · k kanban · t tema · ? ajuda · esc limpa")).toBeVisible();
+  await expect(page.getByRole("dialog", { name: "atalhos e dicas" })).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("dialog", { name: "atalhos e dicas" })).toHaveCount(0);
 
   const html = page.locator("html");
   await expect(html).toHaveClass(/light/);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,11 +10,12 @@ import { Topbar } from "@/components/client/Topbar";
 import { useFilters } from "@/hooks/useFilters";
 import { useShortcuts } from "@/hooks/useShortcuts";
 import { useTheme } from "next-themes";
-import { celebrate } from "@/lib/celebrate";
+import { celebrate, wasTransitionedToDone } from "@/lib/celebrate";
 import { exportJson, parseImport } from "@/lib/io";
 import { deriveStats } from "@/lib/selectors";
 import { visibleProjetos } from "@/lib/filter";
 import { useBoard, setStorageErrorHandler } from "@/lib/store";
+import type { Status } from "@/lib/types";
 import { Dialog, DialogClose, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 
@@ -47,15 +48,15 @@ export default function Home() {
   const isDark = resolvedTheme !== "light";
   const toggleTheme = () => setTheme(isDark ? "light" : "dark");
   const [newProjectOpen, setNewProjectOpen] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
   const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fileRef = useRef<HTMLInputElement | null>(null);
-  const prevDone = useRef(0);
 
   const showToast = useCallback((msg: string) => {
     setToast(msg);
     if (toastTimer.current) clearTimeout(toastTimer.current);
-    toastTimer.current = setTimeout(() => setToast(null), 1600);
+    toastTimer.current = setTimeout(() => setToast(null), 2500);
   }, []);
 
   useEffect(() => {
@@ -65,10 +66,38 @@ export default function Home() {
 
   const boardProjetos = useMemo(() => visibleProjetos(projetos, filters), [projetos, filters]);
   const stats = useMemo(() => deriveStats(boardProjetos), [boardProjetos]);
-  useEffect(() => {
-    if (stats.done > prevDone.current) celebrate();
-    prevDone.current = stats.done;
-  }, [stats.done]);
+
+  const celebrateIfDone = useCallback(
+    (pid: string, sid: string, tid: string, next: Status) => {
+      const t = projetos.find((p) => p.id === pid)?.sections.find((s) => s.id === sid)?.tasks.find((x) => x.id === tid);
+      if (wasTransitionedToDone(t?.status, next)) celebrate();
+    },
+    [projetos],
+  );
+
+  const handleToggleTask = useCallback(
+    (pid: string, sid: string, tid: string) => {
+      const t = projetos.find((p) => p.id === pid)?.sections.find((s) => s.id === sid)?.tasks.find((x) => x.id === tid);
+      if (t && wasTransitionedToDone(t.status, "done")) celebrate();
+      toggleTask(pid, sid, tid);
+    },
+    [projetos, toggleTask],
+  );
+
+  const handleStatusChange = useCallback(
+    (pid: string, sid: string, tid: string, status: Status) => {
+      celebrateIfDone(pid, sid, tid, status);
+      setTaskStatus(pid, sid, tid, status);
+    },
+    [celebrateIfDone, setTaskStatus],
+  );
+
+  const handleFocusAdd = useCallback(() => {
+    const input = document.querySelector<HTMLInputElement>('input[aria-label="nova tarefa"]');
+    if (!input) return;
+    input.scrollIntoView({ block: "center", behavior: "smooth" });
+    input.focus();
+  }, []);
 
   const handleToggleArchive = useCallback(
     (id: string) => {
@@ -116,14 +145,13 @@ export default function Home() {
       onNewProject: () => setNewProjectOpen(true),
       onToggleView: toggleView,
       onToggleTheme: toggleTheme,
-      onHelp: () =>
-        showToast("p projeto · n tarefa · 1-5 filtros · k kanban · t tema · ? ajuda · esc limpa"),
+      onHelp: () => setHelpOpen(true),
       onClearFilters: clear,
-      onFocusAdd: () => {},
+      onFocusAdd: handleFocusAdd,
       onFilterStatus: toggleStatus,
       onUndo: handleUndo,
     },
-    { isModalOpen: () => newProjectOpen },
+    { isModalOpen: () => newProjectOpen || helpOpen },
   );
 
   const counts = stats.byStatus;
@@ -190,9 +218,9 @@ export default function Home() {
             onDelete: (pid, sid) => deleteSection(pid, sid),
           }}
           taskActions={{
-            onToggle: (pid, sid, tid) => toggleTask(pid, sid, tid),
+            onToggle: handleToggleTask,
             onPrioCycle: (pid, sid, tid) => cycleTaskPrio(pid, sid, tid),
-            onStatusChange: (pid, sid, tid, status) => setTaskStatus(pid, sid, tid, status),
+            onStatusChange: handleStatusChange,
             onEdit: (pid, sid, tid, patch) => editTask(pid, sid, tid, patch),
             onDelete: (pid, sid, tid) => deleteTask(pid, sid, tid),
             onMoveTask: (pid, sid, tid, toPid, toSid, index) =>
@@ -307,10 +335,48 @@ export default function Home() {
         />
       )}
 
+      {helpOpen && (
+        <Dialog open onOpenChange={(o) => { if (!o) setHelpOpen(false); }}>
+          <DialogContent
+            showCloseButton={false}
+            className="!sm:max-w-[420px] gap-0 rounded-lg border border-[var(--line-soft)] bg-[var(--panel-2)] p-0 text-[var(--text)] shadow-xl"
+          >
+            <div className="flex items-center justify-between border-b border-[var(--line)] px-4 py-3">
+              <DialogTitle className="text-[13px] font-bold text-[var(--text)]">atalhos e dicas</DialogTitle>
+              <DialogClose
+                render={
+                  <Button type="button" variant="ghost" size="icon-xs" title="fechar" aria-label="fechar">
+                    ×
+                  </Button>
+                }
+              />
+            </div>
+            <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 px-4 py-4 text-xs">
+              <span className="text-[var(--dimmer)]">p</span><span>novo projeto</span>
+              <span className="text-[var(--dimmer)]">n</span><span>focar nova tarefa</span>
+              <span className="text-[var(--dimmer)]">1–5</span><span>filtrar por status</span>
+              <span className="text-[var(--dimmer)]">k</span><span>alternar lista/kanban</span>
+              <span className="text-[var(--dimmer)]">t</span><span>alternar tema claro/escuro</span>
+              <span className="text-[var(--dimmer)]">? </span><span>esta ajuda</span>
+              <span className="text-[var(--dimmer)]">esc</span><span>limpar filtros</span>
+              <span className="text-[var(--dimmer)]">ctrl+z</span><span>desfazer</span>
+            </div>
+            <div className="border-t border-[var(--line)] px-4 py-3 text-xs leading-relaxed text-[var(--muted-text)]">
+              Lista: arraste tarefas entre seções/projetos para mover. Kanban: arraste cartões entre colunas
+              para mudar o status. Dados ficam apenas neste navegador.
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
+
       <PrivacyNotice />
 
       {toast && (
-        <div className="fixed bottom-5 left-1/2 -translate-x-1/2 z-50 bg-[var(--panel-3)] border border-[var(--line)] text-[var(--text)] text-xs px-4 py-2 rounded-md shadow-lg">
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed bottom-16 left-1/2 -translate-x-1/2 z-50 bg-[var(--panel-3)] border border-[var(--line)] text-[var(--text)] text-xs px-4 py-2 rounded-md shadow-lg"
+        >
           {toast}
         </div>
       )}

--- a/src/components/client/Stats.tsx
+++ b/src/components/client/Stats.tsx
@@ -17,8 +17,8 @@ export function Stats({ stats, filters, onTogglePrioSort }: StatsProps) {
 
   const hint =
     filters.view === "kanban"
-      ? "kanban: arraste cartão pra coluna p/ mudar status"
-      : "status-dock: arraste tarefas p/ mudar status";
+      ? "kanban: arraste cartão entre colunas p/ mudar status"
+      : "lista: arraste tarefas entre seções/projetos p/ mover";
 
   return (
     <div className="text-[11px] text-[var(--muted-text)] flex flex-wrap gap-x-4 gap-y-1" role="status">

--- a/src/lib/celebrate.test.ts
+++ b/src/lib/celebrate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { celebrate, chime } from "./celebrate";
+import { celebrate, chime, wasTransitionedToDone } from "./celebrate";
 
 class FakeCtx {
   currentTime = 0;
@@ -64,5 +64,23 @@ vi.mock("canvas-confetti", () => ({
 describe("celebrate", () => {
   it("não explode quando o confetti falha", () => {
     expect(() => celebrate()).not.toThrow();
+  });
+});
+
+describe("wasTransitionedToDone", () => {
+  it("true quando a tarefa não estava done e agora está", () => {
+    expect(wasTransitionedToDone("todo", "done")).toBe(true);
+    expect(wasTransitionedToDone("doing", "done")).toBe(true);
+    expect(wasTransitionedToDone("blocked", "done")).toBe(true);
+  });
+
+  it("false quando já estava done", () => {
+    expect(wasTransitionedToDone("done", "done")).toBe(false);
+  });
+
+  it("false quando não foi para done", () => {
+    expect(wasTransitionedToDone("done", "todo")).toBe(false);
+    expect(wasTransitionedToDone("todo", "todo")).toBe(false);
+    expect(wasTransitionedToDone("todo", "doing")).toBe(false);
   });
 });

--- a/src/lib/celebrate.ts
+++ b/src/lib/celebrate.ts
@@ -40,3 +40,7 @@ export function celebrate(): void {
     return;
   }
 }
+
+export function wasTransitionedToDone(prev: string | undefined, next: string): boolean {
+  return prev !== "done" && next === "done";
+}


### PR DESCRIPTION
# UX/UI C — Feedback e ajuda: confete no momento certo, atalho n, modal de ajuda

Close #66

## O que mudou

### Confete no momento certo
- Novo helper puro `wasTransitionedToDone(prev, next)` em `src/lib/celebrate.ts` (testado: só dispara em transição real → done, nunca em já-done ou para outro status).
- Página (`src/app/page.tsx`): `handleToggleTask` e `handleStatusChange` olham o status **antes** da mutação e chamam `celebrate()` só na transição todo/doing/blocked → done.
- **Removido** o `useEffect` derivado de `stats.done` (disparava confete em qualquer mudança de contagem: filtros, desfazer, import, mover...).

### Atalho "n" real
- Antes: `onFocusAdd: () => {}` (morto). Agora foca o primeiro input `aria-label="nova tarefa"` visível + `scrollIntoView({ block: "center", behavior: "smooth" })`.

### Modal de ajuda ("?")
- Substitui o toast de 1.6s: Dialog persistente "atalhos e dicas" com tabela de atalhos (p, n, 1–5, k, t, ?, esc, ctrl+z) e dicas de drag.
- Fecha com × ou Esc; bloqueia atalhos enquanto aberto (isModalOpen agora considera helpOpen).

### Hints corretos
- Stats.tsx: "status-dock: arraste tarefas p/ mudar status" (não existe) → **"lista: arraste tarefas entre seções/projetos p/ mover"**; kanban: **"arraste cartão entre colunas p/ mudar status"**.

### Toasts acessíveis
- `role="status"` + `aria-live="polite"`, duração 1600ms → **2500ms**, posição `bottom-16` (não sobrepõe o footer).

## Testes (TDD)
- **Unit**: 3 testes `wasTransitionedToDone` (transição, já-done, não-done). Total **206 pass (23 arquivos)**.
- **E2E**: novo `e2e/feedback.spec.ts` (4 testes: "n" foca input, "?" abre/fecha ajuda, confete gera canvas ao concluir, toast com aria-live) + `interactions.spec.ts` atualizado para o modal. Total **45 pass**.
- typecheck limpo.

## Verificação
- 206 unit + 45 e2e verdes; "n" e "?" validados no browser (foco correto, modal renderiza).
