### PR TITLE
UX/UI D — fluxos: kanban rico, empty state com CTA, drag no fim, section button

### DIFF
--- a/e2e/kanban-fluxos.spec.ts
+++ b/e2e/kanban-fluxos.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+async function createProject(page: Page, title: string) {
+  const empty = page.getByRole("button", { name: "+ criar primeiro projeto" });
+  if (await empty.isVisible()) {
+    await empty.click();
+  } else {
+    await page.getByRole("button", { name: "+ projeto" }).click();
+  }
+  await page.getByLabel("título").fill(title);
+  await page.getByRole("button", { name: "criar" }).click();
+}
+
+async function addTask(page: Page, text: string, section = 0) {
+  await page.getByLabel("nova tarefa").nth(section).fill(text);
+  await page.getByLabel("nova tarefa").nth(section).press("Enter");
+}
+
+async function editTask(page: Page, text: string, patch: { prio?: string; due?: string; blocked?: boolean }) {
+  const row = page.getByTestId("task-row").filter({ hasText: text });
+  await row.getByRole("button", { name: "editar", exact: true }).click();
+  const dialog = page.getByRole("dialog", { name: "editar tarefa" });
+  if (patch.prio) await dialog.getByLabel("prioridade").selectOption({ label: patch.prio });
+  if (patch.due) await dialog.getByLabel("vencimento").fill(patch.due);
+  if (patch.blocked) await dialog.getByRole("switch").click();
+  await page.getByRole("button", { name: "salvar" }).click();
+}
+
+async function drag(page: Page, src: Locator, dst: Locator) {
+  const sb = await src.boundingBox();
+  const db = await dst.boundingBox();
+  if (!sb || !db) throw new Error("bounding box indisponível");
+  await page.mouse.move(sb.x + sb.width / 2, sb.y + sb.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(sb.x + sb.width / 2 + 12, sb.y + sb.height / 2, { steps: 4 });
+  await page.mouse.move(db.x + db.width / 2, db.y + db.height / 2, { steps: 12 });
+  await page.mouse.up();
+}
+
+test("kanban rico: card mostra prio, due vencida e bloqueada", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "urgente");
+  await editTask(page, "urgente", { prio: "P1 — urgente", due: "2020-01-01", blocked: true });
+
+  await page.getByRole("button", { name: "kanban" }).click();
+
+  const card = page.getByTestId("kanban-task").filter({ hasText: "urgente" });
+  await expect(card.getByText("P1", { exact: true })).toBeVisible();
+  await expect(card.getByText(/vencida/)).toBeVisible();
+  await expect(card.getByText(/bloqueada/)).toBeVisible();
+});
+
+test("kanban rico: clique no card abre edição e salva mudança", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "na fila");
+
+  await page.getByRole("button", { name: "kanban" }).click();
+  await page.getByRole("button", { name: "editar tarefa na fila", exact: true }).click();
+  const dialog = page.getByRole("dialog", { name: "editar tarefa" });
+  await dialog.getByLabel("tarefa").fill("na fila revisada");
+  await page.getByRole("button", { name: "salvar" }).click();
+
+  await expect(page.getByText("na fila revisada", { exact: true })).toBeVisible();
+});
+
+test("empty state de filtro: CTA limpar filtros restaura a lista", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "tarefa única");
+
+  await page.getByLabel("buscar").fill("não existe");
+  await expect(page.getByText(/nada casa com o filtro/)).toBeVisible();
+
+  await page.getByRole("button", { name: "✕ limpar filtros" }).click();
+
+  await expect(page.getByText("tarefa única", { exact: true })).toBeVisible();
+});
+
+test("drag para o fim da seção adiciona a tarefa no final", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "primeira");
+  await addTask(page, "segunda");
+  await addTask(page, "terceira");
+
+  const rows = page.getByTestId("task-row");
+  const endZone = page.locator('[title="soltar no fim"]');
+  await drag(page, rows.nth(0), endZone);
+
+  await expect(rows.nth(0)).toContainText("segunda");
+  await expect(rows.nth(1)).toContainText("terceira");
+  await expect(rows.nth(2)).toContainText("primeira");
+});
+
+test("section header é botão nativo com aria-expanded", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "tarefa");
+
+  const header = page.getByRole("button", { name: /geral \d\/\d/ });
+  await expect(header).toHaveAttribute("aria-expanded", "true");
+
+  await header.click();
+  await expect(page.getByLabel("nova tarefa")).toHaveCount(0);
+  await expect(header).toHaveAttribute("aria-expanded", "false");
+
+  await header.click();
+  await expect(page.getByLabel("nova tarefa")).toHaveCount(1);
+});
+
+test("Enter no ⋯ da seção não colapsa a seção", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "tarefa");
+
+  await page.getByRole("button", { name: "ações da seção" }).focus();
+  await page.keyboard.press("Enter");
+
+  await expect(page.getByRole("menuitem", { name: "renomear seção" })).toBeVisible();
+  await expect(page.getByLabel("nova tarefa")).toHaveCount(1);
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -205,6 +205,7 @@ export default function Home() {
           projetos={boardProjetos}
           filters={filters}
           onNewProject={() => setNewProjectOpen(true)}
+          onClearFilters={clear}
           projectActions={{
             onAddSection: (pid, title) => addSection(pid, title),
             onRename: (id, title, blocked) => renameProject(id, title, blocked),

--- a/src/components/client/board/Board.test.tsx
+++ b/src/components/client/board/Board.test.tsx
@@ -20,6 +20,7 @@ const base = (over: Partial<BoardProps> = {}): BoardProps => ({
   projetos: [projeto],
   filters: defaultFilters,
   onNewProject: vi.fn(),
+  onClearFilters: vi.fn(),
   projectActions: {
     onAddSection: vi.fn(),
     onRename: vi.fn(),
@@ -55,6 +56,13 @@ describe("Board (lista)", () => {
   it("mostra aviso quando nada casa com o filtro", () => {
     render(<Board {...base({ filters: { ...defaultFilters, query: "inexistente" } })} />);
     expect(screen.getByText(/nada casa com o filtro/)).toBeTruthy();
+  });
+
+  it("CTA limpar filtros no empty state chama onClearFilters", async () => {
+    const p = base({ filters: { ...defaultFilters, query: "inexistente" } });
+    render(<Board {...p} />);
+    await userEvent.click(screen.getByRole("button", { name: "✕ limpar filtros" }));
+    expect(p.onClearFilters).toHaveBeenCalledTimes(1);
   });
 
   it("renderiza projetos correspondentes ao filtro", () => {

--- a/src/components/client/board/Board.tsx
+++ b/src/components/client/board/Board.tsx
@@ -48,12 +48,13 @@ export interface BoardProps {
   projetos: Project[];
   filters: Filters;
   onNewProject: () => void;
+  onClearFilters: () => void;
   projectActions: BoardProjectActions;
   sectionActions: BoardSectionActions;
   taskActions: BoardTaskActions;
 }
 
-export function Board({ projetos, filters, onNewProject, projectActions, sectionActions, taskActions }: BoardProps) {
+export function Board({ projetos, filters, onNewProject, onClearFilters, projectActions, sectionActions, taskActions }: BoardProps) {
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
     useSensor(TouchSensor, { activationConstraint: { distance: 6 } }),
@@ -112,11 +113,24 @@ export function Board({ projetos, filters, onNewProject, projectActions, section
     content = (
       <div className="fade-in rounded-lg border border-dashed border-[var(--line-soft)] p-10 text-center text-[var(--dim)]">
         <span className="block text-2xl">∅</span>
-        <p>nada casa com o filtro.</p>
+        <p className="mb-3">nada casa com o filtro.</p>
+        <button
+          type="button"
+          onClick={onClearFilters}
+          className="rounded-md bg-[var(--fired)] px-3 py-1.5 text-xs font-bold text-primary-foreground"
+        >
+          ✕ limpar filtros
+        </button>
       </div>
     );
   } else if (filters.view === "kanban") {
-    content = <Kanban projetos={filtered} prioSort={filters.prioSort} />;
+    content = (
+      <Kanban
+        projetos={filtered}
+        prioSort={filters.prioSort}
+        onEditTask={(pid, sid, tid, patch) => taskActions.onEdit(pid, sid, tid, patch)}
+      />
+    );
   } else {
     content = (
       <div className="fade-in flex flex-col gap-4">

--- a/src/components/client/board/Section.tsx
+++ b/src/components/client/board/Section.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input";
 import { sortTasks } from "@/lib/filter";
 import type { TaskPatch, Task } from "@/lib/types";
 import { SortableTaskItem } from "@/components/client/dnd/SortableTaskItem";
+import { TaskEditModal } from "@/components/client/board/TaskEditModal";
 
 export interface SectionTaskActions {
   onToggle: (tid: string) => void;
@@ -44,6 +45,7 @@ export function Section({ projectId, section, onToggleSection, onAddTask, onRena
   const [editingId, setEditingId] = useState<string | null>(null);
   const [renaming, setRenaming] = useState(false);
   const { setNodeRef: setDropRef, isOver } = useDroppable({ id: `sec:${projectId}:${section.id}` });
+  const { setNodeRef: setEndRef, isOver: isEndOver } = useDroppable({ id: `sec-end:${projectId}:${section.id}` });
 
   const open = !section.collapsed;
   const doneCount = section.tasks.filter((t) => t.status === "done").length;
@@ -55,41 +57,24 @@ export function Section({ projectId, section, onToggleSection, onAddTask, onRena
     if (String(v.title).trim()) onRename(String(v.title).trim());
   };
 
-  const submitTask = (v: Record<string, string | boolean>) => {
-    if (editingId) {
-      taskActions.onEdit(editingId, {
-        text: String(v.text).trim(),
-        note: String(v.note).trim(),
-        blocked: Boolean(v.blocked),
-        prio: (Number(v.prio) || 3) as Task["prio"],
-        due: String(v.due ?? ""),
-      });
-      setEditingId(null);
-    }
-  };
-
   return (
     <div className="border-t border-dashed border-[var(--line-soft)] first:border-t-0">
-      <div
-        role="button"
-        tabIndex={0}
-        onClick={onToggleSection}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            onToggleSection();
-          }
-        }}
-        className="flex w-full items-center gap-2 bg-[var(--panel-2)] px-3.5 py-2 text-left hover:bg-[var(--panel-3)]"
-        title="expandir/recolher"
-      >
-        <span className={`text-[11px] text-[var(--dimmer)] transition-transform ${open ? "rotate-90" : ""}`}>▶</span>
-        <h3 className="text-[12px] font-semibold uppercase tracking-wider text-[var(--muted-text)]">{section.title}</h3>
-        <span className="text-[11px] text-[var(--dimmer)]">
-          {doneCount}/{section.tasks.length}
-        </span>
-        {section.notes && <span className="ml-auto hidden text-[11px] text-[var(--dimmer)] sm:inline">notas</span>}
-        <span className="ml-auto flex items-center gap-0.5">
+      <div className="flex w-full items-center gap-2 bg-[var(--panel-2)] px-3.5 py-2 hover:bg-[var(--panel-3)]">
+        <button
+          type="button"
+          onClick={onToggleSection}
+          aria-expanded={open}
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+          title="expandir/recolher"
+        >
+          <span className={`text-[11px] text-[var(--dimmer)] transition-transform ${open ? "rotate-90" : ""}`}>▶</span>
+          <h3 className="text-[12px] font-semibold uppercase tracking-wider text-[var(--muted-text)]">{section.title}</h3>
+          <span className="text-[11px] text-[var(--dimmer)]">
+            {doneCount}/{section.tasks.length}
+          </span>
+          {section.notes && <span className="ml-auto hidden text-[11px] text-[var(--dimmer)] sm:inline">notas</span>}
+        </button>
+        <span className="flex items-center gap-0.5">
           <DropdownMenu>
             <DropdownMenuTrigger
               render={
@@ -97,7 +82,6 @@ export function Section({ projectId, section, onToggleSection, onAddTask, onRena
                   type="button"
                   variant="ghost"
                   size="icon-xs"
-                  onClick={(e) => e.stopPropagation()}
                   title="ações da seção"
                   aria-label="ações da seção"
                 >
@@ -153,6 +137,11 @@ export function Section({ projectId, section, onToggleSection, onAddTask, onRena
                 onDelete={() => taskActions.onDelete(t.id)}
               />
             ))}
+            <div
+              ref={setEndRef}
+              className={`h-2 rounded ${isEndOver ? "bg-[var(--fired)]/30" : ""}`}
+              title="soltar no fim"
+            />
           </div>
           <div className="flex items-center gap-2 px-2 pt-2">
             <span className="text-[var(--fired)] font-bold text-xs" aria-hidden>
@@ -189,27 +178,12 @@ export function Section({ projectId, section, onToggleSection, onAddTask, onRena
       )}
 
       {editing && (
-        <Modal
-          title="editar tarefa"
-          submitLabel="salvar"
-          fields={[
-            { key: "text", label: "tarefa", value: editing.text },
-            {
-              key: "prio",
-              label: "prioridade",
-              type: "select",
-              value: editing.prio,
-              options: [
-                { value: 1, label: "P1 — urgente" },
-                { value: 2, label: "P2 — em breve" },
-                { value: 3, label: "P3 — normal" },
-              ],
-            },
-            { key: "due", label: "vencimento", type: "date", value: editing.due },
-            { key: "note", label: "nota", type: "textarea", value: editing.note, placeholder: "detalhe opcional…" },
-            { key: "blocked", label: "marcar como bloqueada / stuck", type: "checkbox", value: editing.blocked },
-          ]}
-          onSubmit={submitTask}
+        <TaskEditModal
+          task={editing}
+          onSubmit={(patch) => {
+            taskActions.onEdit(editing.id, patch);
+            setEditingId(null);
+          }}
           onCancel={() => setEditingId(null)}
         />
       )}

--- a/src/components/client/board/TaskEditModal.tsx
+++ b/src/components/client/board/TaskEditModal.tsx
@@ -1,0 +1,46 @@
+import { Modal } from "@/components/client/Modal";
+import type { Task, TaskPatch } from "@/lib/types";
+
+export interface TaskEditModalProps {
+  task: Task;
+  onSubmit: (patch: TaskPatch) => void;
+  onCancel: () => void;
+}
+
+export function TaskEditModal({ task, onSubmit, onCancel }: TaskEditModalProps) {
+  const submit = (v: Record<string, string | boolean>) => {
+    onSubmit({
+      text: String(v.text).trim(),
+      note: String(v.note).trim(),
+      blocked: Boolean(v.blocked),
+      prio: (Number(v.prio) || 3) as Task["prio"],
+      due: String(v.due ?? ""),
+    });
+  };
+
+  return (
+    <Modal
+      title="editar tarefa"
+      submitLabel="salvar"
+      fields={[
+        { key: "text", label: "tarefa", value: task.text },
+        {
+          key: "prio",
+          label: "prioridade",
+          type: "select",
+          value: task.prio,
+          options: [
+            { value: 1, label: "P1 — urgente" },
+            { value: 2, label: "P2 — em breve" },
+            { value: 3, label: "P3 — normal" },
+          ],
+        },
+        { key: "due", label: "vencimento", type: "date", value: task.due },
+        { key: "note", label: "nota", type: "textarea", value: task.note, placeholder: "detalhe opcional…" },
+        { key: "blocked", label: "marcar como bloqueada / stuck", type: "checkbox", value: task.blocked },
+      ]}
+      onSubmit={submit}
+      onCancel={onCancel}
+    />
+  );
+}

--- a/src/components/client/dnd/Kanban.test.tsx
+++ b/src/components/client/dnd/Kanban.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { Kanban } from "./Kanban";
-import type { Project } from "@/lib/types";
+import type { Project, TaskPatch } from "@/lib/types";
 
-const projeto = (): Project => ({
+const projeto = (over: Partial<Project> = {}): Project => ({
   id: "p1",
   title: "P",
   blocked: false, archived: false,
@@ -21,11 +21,20 @@ const projeto = (): Project => ({
       ],
     },
   ],
+  ...over,
 });
+
+const renderKanban = (props: { projetos?: Project[]; onEditTask?: (pid: string, sid: string, tid: string, patch: TaskPatch) => void } = {}) =>
+  render(
+    <Kanban
+      projetos={props.projetos ?? [projeto()]}
+      onEditTask={props.onEditTask ?? (() => {})}
+    />,
+  );
 
 describe("Kanban", () => {
   it("agrupa tarefas por status em colunas", () => {
-    render(<Kanban projetos={[projeto()]} />);
+    renderKanban();
     expect(screen.getByText("a fazer")).toBeTruthy();
     expect(screen.getByText("em andamento")).toBeTruthy();
     expect(screen.getByText("aguardando")).toBeTruthy();
@@ -34,18 +43,55 @@ describe("Kanban", () => {
     expect(screen.getByText("uprs")).toBeTruthy();
   });
 
-it("mostra contagem por coluna", () => {
-    render(<Kanban projetos={[projeto()]} />);
+  it("mostra contagem por coluna", () => {
+    renderKanban();
     expect(screen.getAllByText("1", { selector: "span" })).toHaveLength(4);
   });
 
   it("mostra origem projeto · seção no card", () => {
-    render(<Kanban projetos={[projeto()]} />);
+    renderKanban();
     expect(screen.getAllByText("P · geral")).toHaveLength(4);
   });
 
   it("estado vazio sem projetos", () => {
-    render(<Kanban projetos={[]} />);
+    renderKanban({ projetos: [] });
     expect(screen.getByText(/nenhuma tarefa para o kanban/)).toBeTruthy();
+  });
+
+  it("mostra prio P1 com destaque no card", () => {
+    renderKanban({
+      projetos: [projeto({ sections: [{ ...projeto().sections[0], tasks: [
+        { ...projeto().sections[0].tasks[0], prio: 1 },
+      ] }] })],
+    });
+    expect(screen.getByText("P1")).toBeTruthy();
+  });
+
+  it("mostra due vencida destacada no card", () => {
+    renderKanban({
+      projetos: [projeto({ sections: [{ ...projeto().sections[0], tasks: [
+        { ...projeto().sections[0].tasks[0], due: "2020-01-01" },
+      ] }] })],
+    });
+    expect(screen.getByText(/vencida/)).toBeTruthy();
+  });
+
+  it("mostra glyph de bloqueada no card", () => {
+    renderKanban({
+      projetos: [projeto({ sections: [{ ...projeto().sections[0], tasks: [
+        { ...projeto().sections[0].tasks[0], blocked: true },
+      ] }] })],
+    });
+    expect(screen.getByText(/bloqueada/)).toBeTruthy();
+  });
+
+  it("clique no card abre o modal de edição e submit chama onEditTask", () => {
+    const onEditTask = vi.fn();
+    renderKanban({ onEditTask });
+    fireEvent.click(screen.getByRole("button", { name: /editar tarefa correr pra base/ }));
+    expect(screen.getByText("editar tarefa")).toBeTruthy();
+    fireEvent.change(screen.getByLabelText("tarefa"), { target: { value: "correr pro topo" } });
+    fireEvent.click(screen.getByText("salvar"));
+    expect(onEditTask).toHaveBeenCalledWith("p1", "s1", "t1", expect.objectContaining({ text: "correr pro topo" }));
   });
 });

--- a/src/components/client/dnd/Kanban.tsx
+++ b/src/components/client/dnd/Kanban.tsx
@@ -1,7 +1,10 @@
+import { useState } from "react";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
 import { sortTasks } from "@/lib/filter";
-import { STATUS_LABEL, STATUS_ORDER, type Project, type Status } from "@/lib/types";
+import { isDueSoon, isOverdue, fmtDate } from "@/lib/date";
+import { PRIO_KEYS, STATUS_LABEL, STATUS_ORDER, type Prio, type Project, type Status } from "@/lib/types";
+import { TaskEditModal } from "@/components/client/board/TaskEditModal";
 
 interface FlatTask {
   task: Project["sections"][number]["tasks"][number];
@@ -14,6 +17,7 @@ interface FlatTask {
 interface KanbanProps {
   projetos: Project[];
   prioSort?: boolean;
+  onEditTask: (pid: string, sid: string, tid: string, patch: import("@/lib/types").TaskPatch) => void;
 }
 
 function flatTasks(projetos: Project[]): FlatTask[] {
@@ -22,28 +26,73 @@ function flatTasks(projetos: Project[]): FlatTask[] {
   );
 }
 
-function KanbanTask({ item }: { item: FlatTask }) {
+const PRIO_CLS: Record<Prio, string> = {
+  1: "bg-[var(--gave)] text-primary-foreground",
+  2: "bg-[var(--warn)] text-primary-foreground",
+  3: "bg-[var(--panel-3)] text-[var(--muted-text)]",
+};
+
+function KanbanTask({ item, onEdit }: { item: FlatTask; onEdit: () => void }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id: `task:${item.task.id}` });
+  const overdue = isOverdue(item.task.due, item.task.status);
+  const dueSoon = isDueSoon(item.task.due, item.task.status);
   return (
     <div
       ref={setNodeRef}
       style={{ transform: CSS.Translate.toString(transform) }}
-      className={`cursor-grab rounded-md border border-[var(--line)] bg-[var(--panel-2)] px-2.5 py-1.5 text-xs ${isDragging ? "opacity-50" : ""}`}
+      className={`cursor-grab rounded-md border border-[var(--line)] bg-[var(--panel-2)] px-2.5 py-1.5 text-xs hover:bg-[var(--panel-3)] ${isDragging ? "opacity-50" : ""}`}
+      data-testid="kanban-task"
       {...attributes}
       {...listeners}
     >
-      <span className={item.task.status === "done" ? "line-through text-[var(--dim)]" : "text-[var(--text)]"}>
-        {item.task.text}
-      </span>
-      <span className="mt-0.5 block text-[10px] text-[var(--dim)]">
-        {item.ptitle} · {item.stitle}
-      </span>
-      {item.task.note && <span className="text-[var(--dim)]"> — {item.task.note}</span>}
+      <div className="flex items-start gap-1.5">
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onEdit();
+          }}
+          className="min-w-0 flex-1 text-left"
+          title="editar tarefa"
+          aria-label={`editar tarefa ${item.task.text}`}
+        >
+          <span className={item.task.status === "done" ? "line-through text-[var(--dim)]" : "text-[var(--text)]"}>
+            {item.task.text}
+          </span>
+          {item.task.note && <span className="text-[var(--dim)]"> — {item.task.note}</span>}
+          <span className="mt-0.5 block text-[10px] text-[var(--dim)]">
+            {item.ptitle} · {item.stitle}
+          </span>
+        </button>
+        <span className={`shrink-0 rounded px-1 py-0.5 text-[9px] font-bold ${PRIO_CLS[item.task.prio]}`}>
+          {PRIO_KEYS[item.task.prio]}
+        </span>
+      </div>
+      <div className="mt-1 flex items-center gap-1.5">
+        {item.task.blocked && (
+          <span className="text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--gave)]" title="bloqueada">
+            ⛔ bloqueada
+          </span>
+        )}
+        {item.task.due &&
+          (overdue ? (
+            <span className="text-[10px] font-bold uppercase text-[var(--gave)]" title={`vencimento ${item.task.due}`}>
+              {fmtDate(item.task.due)} vencida
+            </span>
+          ) : (
+            <span
+              className={`text-[10px] font-semibold ${dueSoon ? "text-[var(--warn)]" : "text-[var(--muted-text)]"}`}
+              title={`vencimento ${item.task.due}`}
+            >
+              {fmtDate(item.task.due)}
+            </span>
+          ))}
+      </div>
     </div>
   );
 }
 
-function DroppableCol({ status, items }: { status: Status; items: FlatTask[] }) {
+function DroppableCol({ status, items, onEdit }: { status: Status; items: FlatTask[]; onEdit: (item: FlatTask) => void }) {
   const { setNodeRef, isOver } = useDroppable({ id: `k:${status}` });
   return (
     <div
@@ -55,14 +104,16 @@ function DroppableCol({ status, items }: { status: Status; items: FlatTask[] }) 
       </header>
       <div className="flex min-h-[48px] flex-col gap-1 p-2">
         {items.map((item) => (
-          <KanbanTask key={item.task.id} item={item} />
+          <KanbanTask key={item.task.id} item={item} onEdit={() => onEdit(item)} />
         ))}
       </div>
     </div>
   );
 }
 
-export function Kanban({ projetos, prioSort }: KanbanProps) {
+export function Kanban({ projetos, prioSort, onEditTask }: KanbanProps) {
+  const [editing, setEditing] = useState<FlatTask | null>(null);
+
   if (!projetos.length) {
     return (
       <div className="fade-in rounded-lg border border-dashed border-[var(--line-soft)] p-10 text-center text-[var(--dim)]">
@@ -75,10 +126,22 @@ export function Kanban({ projetos, prioSort }: KanbanProps) {
   const tasks = sortTasks(flatTasks(projetos), !!prioSort, (i) => i.task.prio);
 
   return (
-    <div className="fade-in flex flex-wrap gap-3">
-      {STATUS_ORDER.map((s) => (
-        <DroppableCol key={s} status={s} items={tasks.filter((t) => t.task.status === s)} />
-      ))}
-    </div>
+    <>
+      <div className="fade-in flex flex-wrap gap-3">
+        {STATUS_ORDER.map((s) => (
+          <DroppableCol key={s} status={s} items={tasks.filter((t) => t.task.status === s)} onEdit={setEditing} />
+        ))}
+      </div>
+      {editing && (
+        <TaskEditModal
+          task={editing.task}
+          onSubmit={(patch) => {
+            onEditTask(editing.pid, editing.sid, editing.task.id, patch);
+            setEditing(null);
+          }}
+          onCancel={() => setEditing(null)}
+        />
+      )}
+    </>
   );
 }

--- a/src/lib/dnd.test.ts
+++ b/src/lib/dnd.test.ts
@@ -48,6 +48,22 @@ describe("resolveDrop", () => {
     expect(r.index).toBe(0);
   });
 
+  it("drop no fim da seção (sec-end) faz append no final", () => {
+    const r = resolveDrop({ projetos: [projeto()], active: "task:t1", over: "sec-end:p1:s1" });
+    expect(r.kind).toBe("move");
+    if (r.kind !== "move") return;
+    expect(r.dest).toEqual({ pid: "p1", sid: "s1" });
+    expect(r.index).toBe(projeto().sections[0].tasks.length);
+  });
+
+  it("drop no fim de seção vazia faz append no índice 0", () => {
+    const r = resolveDrop({ projetos: [projeto()], active: "task:t1", over: "sec-end:p1:s2" });
+    expect(r.kind).toBe("move");
+    if (r.kind !== "move") return;
+    expect(r.dest).toEqual({ pid: "p1", sid: "s2" });
+    expect(r.index).toBe(0);
+  });
+
   it("drop em coluna kanban marca status", () => {
     const r = resolveDrop({ projetos: [projeto()], active: "task:t1", over: "k:done" });
     expect(r.kind).toBe("status");

--- a/src/lib/dnd.ts
+++ b/src/lib/dnd.ts
@@ -38,6 +38,13 @@ export function resolveDrop(args: {
   const src = findTaskRef(projetos, tid);
   if (!src) return { kind: "none" };
 
+  if (over.startsWith("sec-end:")) {
+    const [, pid, sid] = over.split(":");
+    const destSec = projetos.find((p) => p.id === pid)?.sections.find((s) => s.id === sid);
+    if (!destSec) return { kind: "none" };
+    return { kind: "move", src, dest: { pid, sid }, index: destSec.tasks.length };
+  }
+
   if (over.startsWith("sec:")) {
     const [, pid, sid] = over.split(":");
     const destSec = projetos.find((p) => p.id === pid)?.sections.find((s) => s.id === sid);


### PR DESCRIPTION
# UX/UI D — fluxos que travam: kanban rico, empty state, drag no fim, section button

Close #68

## O que mudou

### Kanban rico
- Cards agora mostram **prio** (P1 vermelho / P2 âmbar / P3 neutro), **vencimento** (vencida destacada em vermelho, duesoon em âmbar), **glyph de bloqueada** e **nota** inline.
- **Clique no card abre o Modal de edição** com os mesmos campos da lista (texto, prioridade, vencimento, nota, bloqueada). Modal extraído em `TaskEditModal` compartilhado (Section e Kanban usam o mesmo componente).

### Empty state de filtro
- "nada casa com o filtro." ganhou CTA **"✕ limpar filtros"** (Board recebe `onClearFilters`).

### Drag em lista
- Novo droppable **no fim da seção**: soltar ali faz append no final (`resolveDrop` trata `sec-end:pid:sid` → `index = length`). Antes só existia inserção antes do alvo ou índice 0.

### Section header
- `div role="button"` → **`<button>` nativo com `aria-expanded`**; dropdown de ações virou irmão (button aninhado era HTML inválido). Enter/Espaço no ⋯ abrem o menu sem colapsar a seção (antes o stopPropagation era só no click).

## Testes (TDD)
- **Unit**: `dnd.test.ts` +2 (sec-end append em seção cheia e vazia); `Kanban.test.tsx` +4 (prio, due vencida, bloqueada, clique abre modal + submit chama onEditTask); `Board.test.tsx` +1 (CTA limpar filtros). Total **213 pass (23 arquivos)**.
- **E2E**: novo `e2e/kanban-fluxos.spec.ts` (6 testes: card rico, edição no kanban, CTA limpar filtros, drag pro fim, aria-expanded, Enter no ⋯). Total **51 pass**.

## Verificação
- 213 unit + 51 e2e verdes; typecheck limpo; lint sem erros novos (8 warnings pré-existentes).
