### PR TITLE
Visuais: contraste no claro, worker-src p/ confete, Voltar, drag com ring, LED azul

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,9 @@ const CSP = [
   // 'unsafe-inline' em script: único script inline do app é o ThemeScript
   // (antiflash de tema do next-themes); sem ele há FOUC no primeiro load.
   "script-src 'self' 'unsafe-inline'",
+  // worker-src blob: libera o worker em blob do canvas-confetti (confete);
+  // sem ele o confete cai para fallback no main thread com erro de console.
+  "worker-src 'self' blob:",
   // 'unsafe-inline' em style: transform inline do dnd-kit (drag & drop)
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data:",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,7 +12,7 @@
   --color-popover: var(--panel-2);
   --color-popover-foreground: var(--text);
   --color-primary: var(--fired);
-  --color-primary-foreground: #052e21;
+  --color-primary-foreground: var(--primary-foreground);
   --color-secondary: var(--panel-3);
   --color-secondary-foreground: var(--text);
   --color-muted: var(--panel-3);
@@ -58,6 +58,7 @@
   --muted-text: #8b98a9;
   --dim: #7d8a9c;
   --dimmer: #707c8c;
+  --primary-foreground: #052e21;
   --background: var(--bg);
   --foreground: var(--text);
   --card: var(--panel);
@@ -65,7 +66,6 @@
   --popover: var(--panel-2);
   --popover-foreground: var(--text);
   --primary: var(--fired);
-  --primary-foreground: #052e21;
   --secondary: var(--panel-3);
   --secondary-foreground: var(--text);
   --muted: var(--panel-3);
@@ -81,12 +81,13 @@
 
 html.light {
   color-scheme: light;
-  --fired: #047857;
+  --fired: #059669;
   --gave: #b91c1c;
   --warn: #b45309;
   --flow: #0e7490;
-  --todo: #475569;
+  --todo: #2563eb;
   --violet: #7c3aed;
+  --primary-foreground: #f0fdf4;
   --bg: #f2f4f7;
   --panel: #ffffff;
   --panel-2: #ffffff;

--- a/src/app/privacidade/page.tsx
+++ b/src/app/privacidade/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "Privacidade — OpsBoard",
@@ -36,7 +37,14 @@ const SECTIONS = [
 export default function PrivacidadePage() {
   return (
     <main className="mx-auto max-w-2xl px-4 py-10">
-      <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">Política de privacidade</h1>
+      <Link
+        href="/"
+        className="inline-flex items-center gap-1.5 text-sm text-[var(--muted-text)] hover:text-[var(--text)]"
+        title="voltar para o quadro"
+      >
+        ← Voltar
+      </Link>
+      <h1 className="mt-4 text-2xl font-bold tracking-tight text-[var(--text)]">Política de privacidade</h1>
       <p className="mt-2 text-sm text-[var(--muted-text)]">
         OpsBoard — controle de tarefas. Dados ficam apenas no seu navegador.
       </p>

--- a/src/components/client/Stats.tsx
+++ b/src/components/client/Stats.tsx
@@ -21,7 +21,7 @@ export function Stats({ stats, filters, onTogglePrioSort }: StatsProps) {
       : "lista: arraste tarefas entre seções/projetos p/ mover";
 
   return (
-    <div className="text-[11px] text-[var(--muted-text)] flex flex-wrap gap-x-4 gap-y-1" role="status">
+    <div className="text-[11px] leading-[26px] text-[var(--muted-text)] flex flex-wrap items-center gap-x-4 gap-y-1" role="status">
       <span>
         <span className="text-[var(--dimmer)]">total</span>{" "}
         <span data-testid="stat-total" className="font-bold text-[var(--text)]">{total}</span>

--- a/src/components/client/dnd/Kanban.tsx
+++ b/src/components/client/dnd/Kanban.tsx
@@ -27,9 +27,9 @@ function flatTasks(projetos: Project[]): FlatTask[] {
 }
 
 const PRIO_CLS: Record<Prio, string> = {
-  1: "bg-[var(--gave)] text-primary-foreground",
-  2: "bg-[var(--warn)] text-primary-foreground",
-  3: "bg-[var(--panel-3)] text-[var(--muted-text)]",
+  1: "text-[var(--gave)] border-[var(--gave)]/40 bg-[var(--gave)]/10",
+  2: "text-[var(--warn)] border-[var(--warn)]/40 bg-[var(--warn)]/10",
+  3: "text-[var(--muted-text)] border-[var(--line)]",
 };
 
 function KanbanTask({ item, onEdit }: { item: FlatTask; onEdit: () => void }) {
@@ -40,7 +40,7 @@ function KanbanTask({ item, onEdit }: { item: FlatTask; onEdit: () => void }) {
     <div
       ref={setNodeRef}
       style={{ transform: CSS.Translate.toString(transform) }}
-      className={`cursor-grab rounded-md border border-[var(--line)] bg-[var(--panel-2)] px-2.5 py-1.5 text-xs hover:bg-[var(--panel-3)] ${isDragging ? "opacity-50" : ""}`}
+      className={`cursor-grab rounded-md border border-[var(--line)] bg-[var(--panel-2)] px-2.5 py-1.5 text-xs hover:bg-[var(--panel-3)] ${isDragging ? "opacity-90 shadow-lg ring-2 ring-[var(--fired)]/70 z-10" : ""}`}
       data-testid="kanban-task"
       {...attributes}
       {...listeners}
@@ -64,7 +64,7 @@ function KanbanTask({ item, onEdit }: { item: FlatTask; onEdit: () => void }) {
             {item.ptitle} · {item.stitle}
           </span>
         </button>
-        <span className={`shrink-0 rounded px-1 py-0.5 text-[9px] font-bold ${PRIO_CLS[item.task.prio]}`}>
+        <span className={`shrink-0 rounded border px-1 py-0.5 text-[9px] font-bold ${PRIO_CLS[item.task.prio]}`}>
           {PRIO_KEYS[item.task.prio]}
         </span>
       </div>

--- a/src/components/client/dnd/SortableTaskItem.tsx
+++ b/src/components/client/dnd/SortableTaskItem.tsx
@@ -21,8 +21,8 @@ export function SortableTaskItem({ task, onToggle, onPrioCycle, onStatusChange, 
   return (
     <div
       ref={setNodeRef}
-      style={{ transform: CSS.Transform.toString(transform), transition }}
-      className={isDragging ? "opacity-40" : ""}
+      style={{ transform: CSS.Transform.toString(transform), transition: isDragging ? "none" : transition }}
+      className={`rounded-md ${isDragging ? "opacity-90 shadow-lg ring-2 ring-[var(--fired)]/70 z-10" : ""}`}
       {...attributes}
       {...listeners}
     >

--- a/src/lib/celebrate.ts
+++ b/src/lib/celebrate.ts
@@ -35,7 +35,7 @@ export function chime(): void {
 export function celebrate(): void {
   chime();
   try {
-    confetti({ particleCount: 90, spread: 70, origin: { y: 0.6 }, zIndex: 60 });
+    confetti({ particleCount: 120, spread: 80, origin: { y: 0.6 }, zIndex: 70 });
   } catch {
     return;
   }


### PR DESCRIPTION
# Visuais: contraste do CTA no claro, prio no kanban, LED azul×verde, Voltar, drag com ring, ↕ prio, confete via worker

Close #70

## Causas raiz

1. **CTA verde destoante no claro**: `--primary-foreground` era fixo `#052e21` (verde-escuro) nos 2 temas — sobre `--fired: #047857` no claro o texto quase não se lia. Agora é uma var por tema: dark `#052e21` (mantém), light `#f0fdf4` (texto claro sobre verde).
2. **P1/P2 no kanban com contraste ruim**: badges usavam bg sólido `gave`/`warn` + texto verde-escuro. Agora seguem o padrão do TaskRow: borda + texto colorido sobre fundo translúcido (funciona nos 2 temas).
3. **LED azul × verde no claro**: `--todo` light `#475569` → **`#2563eb`** (azul saturado); `--fired` light `#047857` → **`#059669`**.
4. **Privacidade sem volta**: adicionado link **← Voltar** para `/`.
5. **Drag sem feedback**: item arrastado agora tem `ring-2` na cor primária + sombra + `z-10`; e `transition: none` durante o arrasto — **segue o cursor em tempo real** como o kanban (antes a transition suavizava e "atrasava" o item).
6. **↕ prio desalinhado**: linha de stats com `items-center` + `leading` fixo para casar a altura do botão com os spans.
7. **Confete**: verificado no browser — o confete funcionava, mas o **CSP bloqueava o worker blob do canvas-confetti** (`script-src 'self' 'unsafe-inline'` sem `worker-src`), caindo para fallback com erro de console. Adicionado `worker-src 'self' blob:` — agora roda no worker, **console limpo**. Partículas 90→120, spread 70→80, zIndex 60→70.

## Verificação
- Browser real (headless): toggle concluída → canvas presente, `CONSOLE_ERRORS=0`.
- 213 unit + 51 e2e verdes; typecheck limpo.