### PR TITLE
Busca: título do projeto + filtro granular por tarefa

### DIFF
--- a/e2e/busca.spec.ts
+++ b/e2e/busca.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function createProject(page: Page, title: string) {
+  const empty = page.getByRole("button", { name: "+ criar primeiro projeto" });
+  if (await empty.isVisible()) {
+    await empty.click();
+  } else {
+    await page.getByRole("button", { name: "+ projeto" }).click();
+  }
+  await page.getByLabel("título").fill(title);
+  await page.getByRole("button", { name: "criar" }).click();
+}
+
+async function addTask(page: Page, text: string) {
+  await page.getByLabel("nova tarefa").fill(text);
+  await page.getByLabel("nova tarefa").press("Enter");
+}
+
+test("buscar nome de tarefa mostra só a tarefa que casa", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "teste");
+  await addTask(page, "relatório do cliente");
+  await addTask(page, "reunião de alinhamento");
+  await addTask(page, "pagar fatura");
+
+  await page.getByLabel("buscar tarefas").fill("relatório");
+  await expect(page.getByTestId("task-row")).toHaveCount(1);
+  await expect(page.getByTestId("task-row")).toContainText("relatório do cliente");
+});
+
+test("buscar título do projeto mostra o projeto inteiro", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "teste");
+  await addTask(page, "tarefa um");
+  await addTask(page, "tarefa dois");
+
+  await page.getByLabel("buscar tarefas").fill("teste");
+  await expect(page.getByTestId("task-row")).toHaveCount(2);
+  await expect(page.getByText("tarefa um", { exact: true })).toBeVisible();
+  await expect(page.getByText("tarefa dois", { exact: true })).toBeVisible();
+});
+
+test("buscar sem resultado mostra empty state com CTA e limpar restaura", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "teste");
+  await addTask(page, "tarefa única");
+
+  await page.getByLabel("buscar tarefas").fill("nada disso existe");
+  await expect(page.getByText(/nada casa com o filtro/)).toBeVisible();
+
+  await page.getByRole("button", { name: "✕ limpar filtros" }).click();
+  await expect(page.getByText("tarefa única", { exact: true })).toBeVisible();
+});
+
+test("filtro por status também é granular (só tarefas do status)", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "teste");
+  await addTask(page, "na fila");
+  await addTask(page, "outra na fila");
+
+  await page.getByRole("button", { name: "doing 0" }).click();
+  await expect(page.getByText(/nada casa com o filtro/)).toBeVisible();
+});

--- a/src/components/client/board/Board.tsx
+++ b/src/components/client/board/Board.tsx
@@ -144,6 +144,7 @@ export function Board({ projetos, filters, onNewProject, onClearFilters, project
             onDelete={(id) => projectActions.onDelete(id)}
             onToggleArchive={() => projectActions.onToggleArchive(p.id)}
             prioSort={filters.prioSort}
+            filters={filters}
           />
         ))}
       </div>

--- a/src/components/client/board/ProjectCard.tsx
+++ b/src/components/client/board/ProjectCard.tsx
@@ -12,6 +12,7 @@ import {
 import type { Project, Status, TaskPatch } from "@/lib/types";
 import { Section, type SectionTaskActions as SectionLevelTaskActions } from "./Section";
 import type { SectionLevelActions, TaskLevelActions } from "./Board";
+import type { Filters } from "@/lib/filter";
 
 export interface ProjectActions {
   onAddSection: (title: string) => void;
@@ -30,6 +31,7 @@ export interface ProjectCardProps {
   onDelete: (id: string) => void;
   onToggleArchive: () => void;
   prioSort?: boolean;
+  filters?: Filters;
 }
 
 type ModalState =
@@ -37,7 +39,7 @@ type ModalState =
   | { kind: "add-section" }
   | null;
 
-export function ProjectCard({ project, collectActions, onAddSection, onRename, onDelete, onToggleArchive, prioSort }: ProjectCardProps) {
+export function ProjectCard({ project, collectActions, onAddSection, onRename, onDelete, onToggleArchive, prioSort, filters }: ProjectCardProps) {
   const [modal, setModal] = useState<ModalState>(null);
   const actions = collectActions(project.id);
 
@@ -130,6 +132,7 @@ export function ProjectCard({ project, collectActions, onAddSection, onRename, o
             onDelete={() => actions.sectionActions.onDelete(s.id)}
             taskActions={secTaskActions}
             prioSort={prioSort}
+            filters={filters}
           />
         );
       })}

--- a/src/components/client/board/Section.tsx
+++ b/src/components/client/board/Section.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
-import { sortTasks } from "@/lib/filter";
+import { sortTasks, visibleTasks, type Filters } from "@/lib/filter";
 import type { TaskPatch, Task } from "@/lib/types";
 import { SortableTaskItem } from "@/components/client/dnd/SortableTaskItem";
 import { TaskEditModal } from "@/components/client/board/TaskEditModal";
@@ -38,9 +38,10 @@ export interface SectionProps {
   onDelete: () => void;
   taskActions: SectionTaskActions;
   prioSort?: boolean;
+  filters?: Filters;
 }
 
-export function Section({ projectId, section, onToggleSection, onAddTask, onRename, onDelete, taskActions, prioSort }: SectionProps) {
+export function Section({ projectId, section, onToggleSection, onAddTask, onRename, onDelete, taskActions, prioSort, filters }: SectionProps) {
   const [draft, setDraft] = useState("");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [renaming, setRenaming] = useState(false);
@@ -126,7 +127,7 @@ export function Section({ projectId, section, onToggleSection, onAddTask, onRena
             ref={setDropRef}
             className={`flex flex-col gap-0.5 rounded-md ${isOver ? "outline outline-1 outline-[var(--fired)]/50" : ""}`}
           >
-            {sortTasks(section.tasks, !!prioSort, (t) => t.prio).map((t) => (
+            {sortTasks(filters ? visibleTasks(section.tasks, filters) : section.tasks, !!prioSort, (t) => t.prio).map((t) => (
               <SortableTaskItem
                 key={t.id}
                 task={t}

--- a/src/lib/filter.test.ts
+++ b/src/lib/filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isFiltering, matchTask, projMatches, sectMatches, sortTasks, visibleProjetos, type Filters } from "./filter";
+import { isFiltering, matchTask, projMatches, sectMatches, sortTasks, visibleProjetos, visibleTasks, type Filters } from "./filter";
 import type { Project, Section, Task } from "./types";
 
 const task = (over: Partial<Task> = {}): Task => ({
@@ -96,6 +96,38 @@ describe("projMatches", () => {
   it("não casa projeto sem seções correspondentes", () => {
     const p = project({ sections: [section({ tasks: [task({ text: "a" })] })] });
     expect(projMatches(p, { ...none, status: "doing" })).toBe(false);
+  });
+
+  it("casa projeto cujo título contém a query", () => {
+    expect(projMatches(project({ title: "Projeto Alfa" }), { ...none, query: "alfa" })).toBe(true);
+    expect(projMatches(project({ title: "Projeto Beta" }), { ...none, query: "alfa" })).toBe(false);
+  });
+});
+
+describe("visibleTasks", () => {
+  const tasks = [
+    task({ id: "t1", text: "relatório", status: "todo" }),
+    task({ id: "t2", text: "reunião", status: "doing" }),
+    task({ id: "t3", text: "café", status: "todo", blocked: true }),
+  ];
+
+  it("sem filtros, retorna todas", () => {
+    expect(visibleTasks(tasks, none)).toHaveLength(3);
+  });
+
+  it("com query, retorna só as tarefas que casam", () => {
+    const out = visibleTasks(tasks, { ...none, query: "re" });
+    expect(out.map((t) => t.id)).toEqual(["t1", "t2"]);
+  });
+
+  it("com status, retorna só as tarefas do status", () => {
+    const out = visibleTasks(tasks, { ...none, status: "doing" });
+    expect(out.map((t) => t.id)).toEqual(["t2"]);
+  });
+
+  it("não muta a origem", () => {
+    visibleTasks(tasks, { ...none, query: "café" });
+    expect(tasks).toHaveLength(3);
   });
 });
 

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -32,9 +32,15 @@ export function sectMatches(s: Section, f: Filters): boolean {
   return !!f.query && titleNotesMatch(s, f.query);
 }
 
-/** Projeto visível: alguma seção visível. */
+/** Tarefas visíveis sob filtros: com query/status ativos, só as que casam. */
+export function visibleTasks(tasks: Task[], f: Filters): Task[] {
+  return isFiltering(f) ? tasks.filter((t) => matchTask(t, f)) : tasks;
+}
+
+/** Projeto visível: título casa a query ou alguma seção visível. */
 export function projMatches(p: Project, f: Filters): boolean {
   if (!isFiltering(f)) return true;
+  if (f.query && p.title.toLowerCase().includes(f.query.toLowerCase())) return true;
   return p.sections.some((s) => sectMatches(s, f));
 }
 


### PR DESCRIPTION
# Busca: casa título do projeto e filtra só as tarefas que casam

Close #72

## Causa raiz
- `projMatches` buscava apenas seções/tarefas — **título do projeto era invisível** para a busca.
- Com query/status ativos, a seção inteira era renderizada quando 1 tarefa casava — visualmente "nada mudava" ao buscar por nome de tarefa.

## O que mudou
- `projMatches`: título do projeto casa a query (case-insensitive).
- Novo `visibleTasks(tasks, filters)`: com filtros ativos, retorna só as tarefas que casam (query **e** status agora são granulares).
- `Section` recebe `filters` e renderiza `visibleTasks`; `ProjectCard`/`Board` repassam.
- Projeto que casa só pelo título mostra todas as tarefas; projeto que casa por tarefa mostra só a(s) tarefa(s) que casam.

## Testes (TDD)
- Unit `filter.test.ts`: +5 (título do projeto casa/não casa; visibleTasks com query, status, sem filtro, não muta). Total **218 pass (24 arquivos)**.
- E2E novo `e2e/busca.spec.ts` (4 testes: busca de tarefa mostra só ela, busca de título mostra o projeto, empty state + CTA limpar, status granular). Total **55 pass**.

## Verificação
- 218 unit + 55 e2e verdes; typecheck limpo; lint sem erros (8 warnings pré-existentes).
