### PR TITLE
Kanban clique-drag + stuck no ⋯ do projeto

### DIFF
--- a/e2e/crud.spec.ts
+++ b/e2e/crud.spec.ts
@@ -81,16 +81,24 @@ test("exclui tarefa, seção e projeto (sem confirm nativo, undo cobre)", async 
   await expect(page.getByText("nenhum projeto na fila.")).toBeVisible();
 });
 
-test("renomeia projeto (e marca como bloqueado) e renomeia seção", async ({ page }) => {
+test("renomeia projeto e marca/desmarca stuck pelo ⋯; renomeia seção", async ({ page }) => {
   await page.goto("/");
   await createProject(page, "app");
 
   await page.getByRole("button", { name: "ações do projeto", exact: true }).click();
   await page.getByRole("menuitem", { name: "renomear projeto" }).click();
   await page.getByLabel("título").fill("prod");
-  await page.getByRole("switch").click();
   await page.getByRole("button", { name: "salvar" }).click();
   await expect(page.getByRole("heading", { name: "prod" })).toBeVisible();
+
+  await page.getByRole("button", { name: "ações do projeto", exact: true }).click();
+  await page.getByRole("menuitem", { name: "marcar como stuck / bloqueado" }).click();
+  await expect(page.getByText("stuck", { exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: "ações do projeto", exact: true }).click();
+  await page.getByRole("menuitem", { name: "desmarcar stuck / bloqueado" }).click();
+  await expect(page.getByText("stuck", { exact: true })).toHaveCount(0);
+
   await page.getByRole("button", { name: "ações da seção", exact: true }).click();
   await page.getByRole("menuitem", { name: "renomear seção" }).click();
   await page.getByLabel("título").fill("backlog");

--- a/src/components/client/board/ProjectCard.tsx
+++ b/src/components/client/board/ProjectCard.tsx
@@ -46,7 +46,7 @@ export function ProjectCard({ project, collectActions, onAddSection, onRename, o
   const submitProject = (v: Record<string, string | boolean>) => {
     setModal(null);
     if (!String(v.title).trim()) return;
-    onRename(project.id, String(v.title).trim(), Boolean(v.blocked));
+    onRename(project.id, String(v.title).trim(), project.blocked);
   };
 
   const submitSection = (v: Record<string, string | boolean>) => {
@@ -97,6 +97,12 @@ export function ProjectCard({ project, collectActions, onAddSection, onRename, o
               >
                 renomear projeto
               </DropdownMenuItem>
+              <DropdownMenuItem
+                className="text-xs"
+                onClick={() => onRename(project.id, project.title, !project.blocked)}
+              >
+                {project.blocked ? "desmarcar stuck / bloqueado" : "marcar como stuck / bloqueado"}
+              </DropdownMenuItem>
               <DropdownMenuItem className="text-xs" onClick={onToggleArchive}>
                 {project.archived ? "desarquivar projeto" : "arquivar projeto"}
               </DropdownMenuItem>
@@ -143,7 +149,6 @@ export function ProjectCard({ project, collectActions, onAddSection, onRename, o
           submitLabel="salvar"
           fields={[
             { key: "title", label: "título", value: project.title },
-            { key: "blocked", label: "marcar como stuck / bloqueado", type: "checkbox", value: project.blocked },
           ]}
           onSubmit={submitProject}
           onCancel={() => setModal(null)}

--- a/src/components/client/dnd/Kanban.test.tsx
+++ b/src/components/client/dnd/Kanban.test.tsx
@@ -85,7 +85,7 @@ describe("Kanban", () => {
     expect(screen.getByText(/bloqueada/)).toBeTruthy();
   });
 
-  it("clique no card abre o modal de edição e submit chama onEditTask", () => {
+it("clique no card abre o modal de edição e submit chama onEditTask", () => {
     const onEditTask = vi.fn();
     renderKanban({ onEditTask });
     fireEvent.click(screen.getByRole("button", { name: /editar tarefa correr pra base/ }));
@@ -93,5 +93,22 @@ describe("Kanban", () => {
     fireEvent.change(screen.getByLabelText("tarefa"), { target: { value: "correr pro topo" } });
     fireEvent.click(screen.getByText("salvar"));
     expect(onEditTask).toHaveBeenCalledWith("p1", "s1", "t1", expect.objectContaining({ text: "correr pro topo" }));
+  });
+
+  it("click após drag (>6px) não abre o modal", () => {
+    const onEditTask = vi.fn();
+    renderKanban({ onEditTask });
+    const card = screen.getByRole("button", { name: /editar tarefa correr pra base/ });
+    fireEvent.pointerDown(card, { clientX: 10, clientY: 10 });
+    fireEvent.click(card, { clientX: 40, clientY: 10 });
+    expect(screen.queryByText("editar tarefa")).toBeNull();
+  });
+
+  it("click sem movimento abre o modal", () => {
+    renderKanban();
+    const card = screen.getByRole("button", { name: /editar tarefa correr pra base/ });
+    fireEvent.pointerDown(card, { clientX: 10, clientY: 10 });
+    fireEvent.click(card, { clientX: 12, clientY: 11 });
+    expect(screen.getByText("editar tarefa")).toBeTruthy();
   });
 });

--- a/src/components/client/dnd/Kanban.tsx
+++ b/src/components/client/dnd/Kanban.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
 import { sortTasks } from "@/lib/filter";
@@ -34,6 +34,7 @@ const PRIO_CLS: Record<Prio, string> = {
 
 function KanbanTask({ item, onEdit }: { item: FlatTask; onEdit: () => void }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id: `task:${item.task.id}` });
+  const start = useRef<{ x: number; y: number } | null>(null);
   const overdue = isOverdue(item.task.due, item.task.status);
   const dueSoon = isDueSoon(item.task.due, item.task.status);
   return (
@@ -42,20 +43,32 @@ function KanbanTask({ item, onEdit }: { item: FlatTask; onEdit: () => void }) {
       style={{ transform: CSS.Translate.toString(transform) }}
       className={`cursor-grab rounded-md border border-[var(--line)] bg-[var(--panel-2)] px-2.5 py-1.5 text-xs hover:bg-[var(--panel-3)] ${isDragging ? "opacity-90 shadow-lg ring-2 ring-[var(--fired)]/70 z-10" : ""}`}
       data-testid="kanban-task"
+      aria-label={`editar tarefa ${item.task.text}`}
+      title="clique pra editar, arraste pra mover"
+      onPointerDown={(e) => {
+        start.current = { x: e.clientX, y: e.clientY };
+      }}
+      onClick={(e) => {
+        const s = start.current;
+        start.current = null;
+        if (!s) {
+          onEdit();
+          return;
+        }
+        const moved = Math.abs(e.clientX - s.x) > 6 || Math.abs(e.clientY - s.y) > 6;
+        if (!moved) onEdit();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onEdit();
+        }
+      }}
       {...attributes}
       {...listeners}
     >
       <div className="flex items-start gap-1.5">
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onEdit();
-          }}
-          className="min-w-0 flex-1 text-left"
-          title="editar tarefa"
-          aria-label={`editar tarefa ${item.task.text}`}
-        >
+        <span className="min-w-0 flex-1">
           <span className={item.task.status === "done" ? "line-through text-[var(--dim)]" : "text-[var(--text)]"}>
             {item.task.text}
           </span>
@@ -63,7 +76,7 @@ function KanbanTask({ item, onEdit }: { item: FlatTask; onEdit: () => void }) {
           <span className="mt-0.5 block text-[10px] text-[var(--dim)]">
             {item.ptitle} · {item.stitle}
           </span>
-        </button>
+        </span>
         <span className={`shrink-0 rounded border px-1 py-0.5 text-[9px] font-bold ${PRIO_CLS[item.task.prio]}`}>
           {PRIO_KEYS[item.task.prio]}
         </span>


### PR DESCRIPTION
# Kanban: clique abre edição, drag move; stuck/bloqueado no ⋯ do projeto

Close #74

## Kanban — clique vs drag
- O card inteiro agora é o botão de editar (`role="button"` via dnd-kit + `aria-label`): **clique em qualquer lugar abre o Modal de edição**.
- **Guard de drag**: pointerdown grava a posição; se o click veio com movimento >6px (o mesmo limiar do sensor), o click é ignorado — arrastar move o card sem abrir o modal.
- Enter/Espaço no card (teclado) também abrem a edição.
- O botão interno "editar tarefa" foi removido (era o único lugar clicável).

## Stuck/bloqueado do projeto
- Saiu do modal "editar projeto" → virou item direto no ⋯: **"marcar como stuck / bloqueado"** / "desmarcar..." (toggle imediato).
- Modal de renomear ficou só com o título.

## Testes (TDD)
- Unit `Kanban.test.tsx`: +2 (click pós-drag >6px não abre modal; click sem movimento abre). Total **220 pass (24 arquivos)**.
- E2E: `crud.spec.ts` atualizado (stuck/desmarcar via ⋯); drag/dnd/kanban-fluxos/busca verdes. Total **55 pass**.

## Verificação
- 220 unit + 55 e2e verdes; typecheck limpo; lint sem erros.
