### PR TITLE
feat: stats no header via tooltip; ↕ prio nos filtros

### DIFF
--- a/e2e/archive.spec.ts
+++ b/e2e/archive.spec.ts
@@ -23,6 +23,11 @@ async function addTask(page: Page, projectTitle: string, text: string) {
 const archiveMenu = (page: Page, title: string) =>
   projectCard(page, title).getByLabel("ações do projeto");
 
+async function expectStat(page: Page, testid: string, text: string) {
+  await page.getByRole("heading", { name: /ops\/board/ }).hover();
+  await expect(page.getByTestId(testid)).toHaveText(text);
+}
+
 test("chip arquivados filtra de verdade: só arquivados visíveis; limpar reseta", async ({ page }) => {
   await page.goto("/");
   await createProject(page, "Ativo A");
@@ -34,7 +39,7 @@ test("chip arquivados filtra de verdade: só arquivados visíveis; limpar reseta
   await page.getByRole("menuitem", { name: "arquivar projeto" }).click();
 
   await expect(page.getByText("Arquivo P")).toHaveCount(0);
-  await expect(page.getByTestId("stat-total")).toHaveText("1");
+  await expectStat(page, "stat-total", "1");
   const chip = page.getByRole("button", { name: /arquivados/ });
   await expect(chip).toContainText("1");
   await expect(page.getByRole("button", { name: "✕ limpar" })).toHaveCount(0);
@@ -43,7 +48,7 @@ test("chip arquivados filtra de verdade: só arquivados visíveis; limpar reseta
   await expect(page.getByText("Arquivo P")).toBeVisible();
   await expect(page.getByText("Ativo A")).toHaveCount(0);
   await expect(page.getByText("arquivado", { exact: true })).toBeVisible();
-  await expect(page.getByTestId("stat-total")).toHaveText("1");
+  await expectStat(page, "stat-total", "1");
   await expect(page.getByRole("button", { name: "✕ limpar" })).toBeVisible();
 
   await page.getByLabel("ações do projeto").click();
@@ -54,7 +59,7 @@ test("chip arquivados filtra de verdade: só arquivados visíveis; limpar reseta
 
   await page.getByRole("button", { name: "✕ limpar" }).click();
   await expect(page.getByText("Arquivo P")).toBeVisible();
-  await expect(page.getByTestId("stat-total")).toHaveText("2");
+  await expectStat(page, "stat-total", "2");
   await expect(page.getByRole("button", { name: /arquivados/ })).toHaveAttribute("aria-pressed", "false");
 });
 

--- a/e2e/feedback.spec.ts
+++ b/e2e/feedback.spec.ts
@@ -54,5 +54,6 @@ test("concluir tarefa dispara confete (canvas) e toast acessível de backup", as
 
 test("hint da lista descreve arraste entre seções/projetos", async ({ page }) => {
   await page.goto("/");
+  await page.getByRole("heading", { name: /ops\/board/ }).hover();
   await expect(page.getByText(/lista: arraste tarefas entre seções\/projetos/)).toBeVisible();
 });

--- a/e2e/interactions.spec.ts
+++ b/e2e/interactions.spec.ts
@@ -106,10 +106,13 @@ test("ordena por prioridade (P1 no topo) com ↕ prio", async ({ page }) => {
   await expect(rows.nth(0)).toContainText("tarefa b");
   await expect(rows.nth(1)).toContainText("tarefa a");
 
+
   await rows.nth(1).getByRole("button", { name: "prioridade: clique pra mudar" }).click();
   await expect(rows.nth(1)).toContainText("P1");
 
-  await page.getByRole("button", { name: "↕ prio" }).click();
+  await page.getByRole("heading", { name: /ops\/board/ }).hover();
+  await expect(page.getByRole("button", { name: "↕ prio" })).toBeVisible();
+  await page.getByRole("button", { name: "↕ prio" }).click({ force: true });
   await expect(rows.nth(0)).toContainText("tarefa a");
   await expect(rows.nth(1)).toContainText("tarefa b");
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,6 @@ import { Board } from "@/components/client/board/Board";
 import { FilterChips } from "@/components/client/FilterChips";
 import { Modal } from "@/components/client/Modal";
 import { PrivacyNotice } from "@/components/client/PrivacyNotice";
-import { Stats } from "@/components/client/Stats";
 import { Topbar } from "@/components/client/Topbar";
 import { useT } from "@/hooks/useT";
 import { useFilters } from "@/hooks/useFilters";
@@ -178,6 +177,7 @@ export default function Home() {
         onImport={() => setConfirmImportOpen(true)}
         locale={locale}
         onToggleLocale={() => setLocale(locale === "pt" ? "en" : "pt")}
+        stats={stats}
       />
       <input
         ref={fileRef}
@@ -202,12 +202,10 @@ export default function Home() {
           onToggleStatus={toggleStatus}
           onToggleArchived={toggleArchived}
           onClear={clear}
+          prioSort={filters.prioSort}
+          onTogglePrioSort={togglePrioSort}
         />
       </div>
-      <div className="mx-auto max-w-5xl px-4 pb-2">
-        <Stats stats={stats} filters={filters} onTogglePrioSort={togglePrioSort} />
-      </div>
-
       <main className="mx-auto max-w-5xl px-4 py-6">
         <Board
           projetos={boardProjetos}

--- a/src/components/client/FilterChips.test.tsx
+++ b/src/components/client/FilterChips.test.tsx
@@ -6,13 +6,25 @@ import { FilterChips } from "./FilterChips";
 const base = {
   counts: { todo: 2, doing: 1, waiting: 0, done: 3 },
   blockedCount: 1,
+  archivedCount: 0,
+  archivedActive: false,
   active: null as null,
   filtering: false,
   onToggleStatus: vi.fn(),
+  onToggleArchived: vi.fn(),
   onClear: vi.fn(),
+  prioSort: false,
+  onTogglePrioSort: vi.fn(),
 };
 
 describe("FilterChips", () => {
+  it("toggle de prioridade invoca callback", async () => {
+    const onTogglePrioSort = vi.fn();
+    render(<FilterChips {...base} onTogglePrioSort={onTogglePrioSort} />);
+    await userEvent.click(screen.getByRole("button", { name: "↕ prio" }));
+    expect(onTogglePrioSort).toHaveBeenCalledTimes(1);
+  });
+
   it("mostra contagem de arquivados e alterna visibilidade", async () => {
     const onToggleArchived = vi.fn();
     render(<FilterChips {...base} archivedCount={4} archivedActive={false} onToggleArchived={onToggleArchived} />);

--- a/src/components/client/FilterChips.tsx
+++ b/src/components/client/FilterChips.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { StatusFilter } from "@/lib/filter";
 import type { Status } from "@/lib/types";
 import { useT } from "@/hooks/useT";
@@ -28,6 +29,8 @@ interface FilterChipsProps {
   onToggleStatus: (status: StatusFilter) => void;
   onToggleArchived: () => void;
   onClear: () => void;
+  prioSort: boolean;
+  onTogglePrioSort: () => void;
 }
 
 export function FilterChips({
@@ -40,6 +43,8 @@ export function FilterChips({
   onToggleStatus,
   onToggleArchived,
   onClear,
+  prioSort,
+  onTogglePrioSort,
 }: FilterChipsProps) {
   const { t, status } = useT();
   return (
@@ -75,6 +80,23 @@ export function FilterChips({
         arquivados
         <span className="opacity-60">{archivedCount}</span>
       </Button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              type="button"
+              variant={prioSort ? "outline" : "ghost"}
+              size="xs"
+              onClick={onTogglePrioSort}
+              aria-pressed={prioSort}
+              className={`text-[var(--muted-text)] ${prioSort ? "border-current text-[var(--warn)] bg-[var(--hover)]" : ""}`}
+            >
+              ↕ prio
+            </Button>
+          }
+        />
+        <TooltipContent side="bottom">{t("filtro de prioridade (P1 no topo)")}</TooltipContent>
+      </Tooltip>
       {filtering && (
         <Button
           type="button"

--- a/src/components/client/Stats.test.tsx
+++ b/src/components/client/Stats.test.tsx
@@ -1,8 +1,7 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { Stats } from "../../components/client/Stats";
-import { defaultFilters, type Filters } from "../../lib/filter";
+
 import { todayISO } from "../../lib/date";
 import { deriveStats, type BoardStats } from "../../lib/selectors";
 import type { Project } from "../../lib/types";
@@ -39,8 +38,7 @@ describe("Stats", () => {
             task({ id: "t3", status: "done", doneAt: todayISO() + "T09:00:00.000Z" }),
           ]),
         ])}
-        filters={defaultFilters}
-        onTogglePrioSort={() => {}}
+        view="list"
       />,
     );
     expect(screen.getByText("3")).toBeTruthy();
@@ -53,25 +51,14 @@ describe("Stats", () => {
     render(
       <Stats
         stats={statsOf([projeto([task()])])}
-        filters={defaultFilters}
-        onTogglePrioSort={() => {}}
+        view="list"
       />,
     );
     expect(screen.getByText("(0%)")).toBeTruthy();
   });
 
-  it("toggle de prioridade invoca callback", async () => {
-    const onTogglePrioSort = vi.fn();
-    render(
-      <Stats stats={statsOf([projeto([])])} filters={defaultFilters} onTogglePrioSort={onTogglePrioSort} />,
-    );
-    await userEvent.click(screen.getByRole("button", { name: "↕ prio" }));
-    expect(onTogglePrioSort).toHaveBeenCalledTimes(1);
-  });
-
   it("destaca dica de kanban quando em kanban", () => {
-    const f: Filters = { ...defaultFilters, view: "kanban" };
-    render(<Stats stats={statsOf([])} filters={f} onTogglePrioSort={() => {}} />);
+    render(<Stats stats={statsOf([])} view="kanban" />);
     expect(screen.getByText(/kanban: arraste/i)).toBeTruthy();
   });
 
@@ -85,8 +72,7 @@ describe("Stats", () => {
             task({ id: "t3", status: "done", doneAt: todayISO() + "T09:00:00.000Z" }),
           ]),
         ])}
-        filters={defaultFilters}
-        onTogglePrioSort={() => {}}
+        view="list"
       />,
     );
     expect(screen.getByTestId("stat-total")).toHaveTextContent("3");

--- a/src/components/client/Stats.tsx
+++ b/src/components/client/Stats.tsx
@@ -1,24 +1,21 @@
-import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useT } from "@/hooks/useT";
 import type { BoardStats } from "@/lib/selectors";
-import type { Filters } from "@/lib/filter";
+
 
 interface StatsProps {
   stats: BoardStats;
-  filters: Filters;
-  onTogglePrioSort: () => void;
+  view: "list" | "kanban";
 }
 
 const fmtPct = (done: number, total: number) => (total ? Math.round((done / total) * 100) : 0);
 
-export function Stats({ stats, filters, onTogglePrioSort }: StatsProps) {
+export function Stats({ stats, view }: StatsProps) {
   const { t } = useT();
   const { done, total, pendentes, doneToday } = stats;
   const pct = fmtPct(done, total);
 
   const hint =
-    filters.view === "kanban"
+    view === "kanban"
       ? t("kanban: arraste cartão entre colunas p/ mudar status")
       : t("lista: arraste tarefas entre seções/projetos p/ mover");
 
@@ -41,22 +38,6 @@ export function Stats({ stats, filters, onTogglePrioSort }: StatsProps) {
         <span className="text-[var(--dimmer)]">{t("hoje")}</span>{" "}
         <span data-testid="stat-today" className="text-[var(--fired)]">+{doneToday}</span>
       </span>
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <Button
-              type="button"
-              variant={filters.prioSort ? "outline" : "ghost"}
-              size="xs"
-              onClick={onTogglePrioSort}
-              className={`text-[var(--muted-text)] ${filters.prioSort ? "border-current text-[var(--warn)] bg-[var(--hover)]" : ""}`}
-            >
-              ↕ prio
-            </Button>
-          }
-        />
-        <TooltipContent side="bottom">{t("filtro de prioridade (P1 no topo)")}</TooltipContent>
-      </Tooltip>
       <span className="ml-auto text-[var(--dim)] hidden sm:inline">{hint}</span>
     </div>
   );

--- a/src/components/client/Topbar.tsx
+++ b/src/components/client/Topbar.tsx
@@ -7,6 +7,8 @@ import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { View } from "@/lib/filter";
+import { Stats } from "@/components/client/Stats";
+import type { BoardStats } from "@/lib/selectors";
 
 interface TopbarProps {
   query: string;
@@ -21,6 +23,7 @@ interface TopbarProps {
   onImport: () => void;
   locale: Locale;
   onToggleLocale: () => void;
+  stats: BoardStats;
 }
 
 const DEBOUNCE_MS = 200;
@@ -38,6 +41,7 @@ export function Topbar({
   onImport,
   locale,
   onToggleLocale,
+  stats,
 }: TopbarProps) {
   const { t } = useT();
   const [draft, setDraft] = useState(query);
@@ -62,12 +66,21 @@ export function Topbar({
     <header className="sticky top-0 z-30 border-b border-[var(--line)] bg-[var(--bg)]/95 backdrop-blur">
       <div className="mx-auto max-w-5xl px-4 py-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-6">
         <div className="flex items-center justify-between gap-4">
-          <h1 className="text-sm font-bold tracking-tight text-[var(--text)]">
-            ops<span className="text-[var(--fired)]">/</span>board
-          </h1>
+          <Tooltip>
+            <TooltipTrigger closeDelay={300}
+              render={
+                <h1 className="text-sm font-bold tracking-tight text-[var(--text)] cursor-help">
+                  ops<span className="text-[var(--fired)]">/</span>board
+                </h1>
+              }
+            />
+            <TooltipContent side="bottom" className="z-40">
+              <Stats stats={stats} view={view} />
+            </TooltipContent>
+          </Tooltip>
           <div className="flex items-center gap-1.5">
             <Tooltip>
-            <TooltipTrigger
+            <TooltipTrigger closeDelay={300}
               render={
                 <Button
                   type="button"


### PR DESCRIPTION
Closes #82

- Stats movido para tooltip do título no Topbar (hover/focus no nome do app)
- testids `stat-total`, `stat-pending`, `stat-done`, `stat-today` preservados (e2e/archive.spec usa helper com hover)
- Botão ↕ prio migra para FilterChips (tooltip aninhado no header não era estável p/ clique)
- Stats simplificado: props `stats` + `view` apenas
- unit: Stats.test sem toggle prio (move p/ FilterChips.test +1); 243 unit
- e2e: archive/feedback/interactions ajustados p/ hover no título; 62 e2e verdes