### PR TITLE
feat: drag na lista com reorder em tempo real

### DIFF
--- a/e2e/dnd.spec.ts
+++ b/e2e/dnd.spec.ts
@@ -51,6 +51,26 @@ test("reordena tarefa dentro da seção por arrasto", async ({ page }) => {
   await expect(rows.nth(1)).toContainText("primeira");
 });
 
+test("reordena tarefa para baixo de outra na mesma seção por arrasto", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "primeira");
+  await addTask(page, "segunda");
+  await addTask(page, "terceira");
+
+  const rows = page.getByTestId("task-row");
+  await expect(rows).toHaveCount(3);
+  await expect(rows.nth(0)).toContainText("primeira");
+  await expect(rows.nth(1)).toContainText("segunda");
+  await expect(rows.nth(2)).toContainText("terceira");
+
+  await drag(page, rows.nth(0), rows.nth(1));
+
+  await expect(rows.nth(0)).toContainText("segunda");
+  await expect(rows.nth(1)).toContainText("primeira");
+  await expect(rows.nth(2)).toContainText("terceira");
+});
+
 test("move tarefa entre seções por arrasto", async ({ page }) => {
   await page.goto("/");
   await createProject(page, "app");

--- a/src/components/client/board/Board.tsx
+++ b/src/components/client/board/Board.tsx
@@ -1,4 +1,4 @@
-import { DndContext, PointerSensor, TouchSensor, pointerWithin, useSensor, useSensors, type DragEndEvent } from "@dnd-kit/core";
+import { DndContext, PointerSensor, TouchSensor, rectIntersection, useSensor, useSensors, type DragEndEvent } from "@dnd-kit/core";
 import { useMemo } from "react";
 import { useT } from "@/hooks/useT";
 import { isFiltering, prioSort, projMatches, type Filters } from "@/lib/filter";
@@ -161,7 +161,7 @@ export function Board({ projetos, filters, onNewProject, onClearFilters, project
   }
 
   return (
-    <DndContext sensors={sensors} collisionDetection={pointerWithin} onDragEnd={handleDragEnd}>
+    <DndContext sensors={sensors} collisionDetection={rectIntersection} onDragEnd={handleDragEnd}>
       {content}
     </DndContext>
   );

--- a/src/components/client/board/Section.tsx
+++ b/src/components/client/board/Section.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useT } from "@/hooks/useT";
 import { useDroppable } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { Modal } from "@/components/client/Modal";
 import { Button } from "@/components/ui/button";
 import {
@@ -130,18 +131,23 @@ export function Section({ projectId, section, onToggleSection, onAddTask, onRena
             ref={setDropRef}
             className={`flex flex-col gap-0.5 rounded-md ${isOver ? "outline outline-1 outline-[var(--fired)]/50" : ""}`}
           >
-            {sortTasks(filters ? visibleTasks(section.tasks, filters) : section.tasks, !!prioSort, (t) => t.prio).map((t) => (
-              <SortableTaskItem
-                key={t.id}
-                task={t}
-                onToggle={() => taskActions.onToggle(t.id)}
-                onPrioCycle={() => taskActions.onPrioCycle(t.id)}
-                onStatusChange={(status) => taskActions.onStatusChange(t.id, status)}
-                onEdit={() => setEditingId(t.id)}
-                onDelete={() => taskActions.onDelete(t.id)}
-                onUpdate={(patch) => taskActions.onUpdate(t.id, patch)}
-              />
-            ))}
+            <SortableContext
+              items={sortTasks(filters ? visibleTasks(section.tasks, filters) : section.tasks, !!prioSort, (t) => t.prio).map((t) => `task:${t.id}`)}
+              strategy={verticalListSortingStrategy}
+            >
+              {sortTasks(filters ? visibleTasks(section.tasks, filters) : section.tasks, !!prioSort, (t) => t.prio).map((t) => (
+                <SortableTaskItem
+                  key={t.id}
+                  task={t}
+                  onToggle={() => taskActions.onToggle(t.id)}
+                  onPrioCycle={() => taskActions.onPrioCycle(t.id)}
+                  onStatusChange={(status) => taskActions.onStatusChange(t.id, status)}
+                  onEdit={() => setEditingId(t.id)}
+                  onDelete={() => taskActions.onDelete(t.id)}
+                  onUpdate={(patch) => taskActions.onUpdate(t.id, patch)}
+                />
+              ))}
+            </SortableContext>
             <div
               ref={setEndRef}
               className={`h-2 rounded ${isEndOver ? "bg-[var(--fired)]/30" : ""}`}


### PR DESCRIPTION
Closes #88

- Section: SortableContext + verticalListSortingStrategy por seção (items = task ids, respeita filtro/prioSort)
- Board: collision rectIntersection (item totalmente coberto vence sec:, sec-end vence no fim da seção — append intacto)
- resolveDrop task→task já tinha semântica arrayMove (posição visual = posição final); task→sec/sec-end (borda cross-seção) inalterado
- e2e dnd.spec +1 (reordena para baixo; a existente cobria para cima); 18 e2e + 247 unit verdes