### PR TITLE
feat: criar tarefa inline nas colunas do kanban

### DIFF
--- a/e2e/kanban-fluxos.spec.ts
+++ b/e2e/kanban-fluxos.spec.ts
@@ -121,3 +121,20 @@ test("Enter no ⋯ da seção não colapsa a seção", async ({ page }) => {
   await expect(page.getByRole("menuitem", { name: "renomear seção" })).toBeVisible();
   await expect(page.getByLabel("nova tarefa")).toHaveCount(1);
 });
+
+test("kanban: cria card direto na coluna a fazer", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+
+  await page.getByRole("button", { name: "kanban" }).click();
+
+  const input = page.getByLabel("nova tarefa").first();
+  await input.fill("nova card");
+  await input.press("Enter");
+
+  const card = page.getByTestId("kanban-task").filter({ hasText: "nova card" });
+  await expect(card).toBeVisible();
+
+  await page.getByRole("button", { name: "lista" }).click();
+  await expect(page.getByText("nova card", { exact: true })).toBeVisible();
+});

--- a/src/components/client/board/Board.tsx
+++ b/src/components/client/board/Board.tsx
@@ -136,6 +136,7 @@ export function Board({ projetos, filters, onNewProject, onClearFilters, project
         projetos={filtered}
         prioSort={filters.prioSort}
         onEditTask={(pid, sid, tid, patch) => taskActions.onEdit(pid, sid, tid, patch)}
+        onAddTask={(pid, sid, text) => sectionActions.onAddTask(pid, sid, text)}
       />
     );
   } else {

--- a/src/components/client/dnd/Kanban.test.tsx
+++ b/src/components/client/dnd/Kanban.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { Kanban } from "./Kanban";
 import type { Project, TaskPatch } from "@/lib/types";
@@ -24,11 +25,12 @@ const projeto = (over: Partial<Project> = {}): Project => ({
   ...over,
 });
 
-const renderKanban = (props: { projetos?: Project[]; onEditTask?: (pid: string, sid: string, tid: string, patch: TaskPatch) => void } = {}) =>
+const renderKanban = (props: { projetos?: Project[]; onEditTask?: (pid: string, sid: string, tid: string, patch: TaskPatch) => void; onAddTask?: (pid: string, sid: string, text: string) => void } = {}) =>
   render(
     <Kanban
       projetos={props.projetos ?? [projeto()]}
       onEditTask={props.onEditTask ?? (() => {})}
+      onAddTask={props.onAddTask ?? (() => {})}
     />,
   );
 
@@ -135,5 +137,48 @@ it("clique no card abre o modal de edição e submit chama onEditTask", () => {
     expect(onEditTask).toHaveBeenCalledWith("p1", "s1", "t1", expect.objectContaining({
       subs: [expect.objectContaining({ text: "aquecer", done: true })],
     }));
+  });
+
+  it("Enter no input da coluna cria tarefa com projeto, status e texto", () => {
+    const onAddTask = vi.fn();
+    renderKanban({ onAddTask });
+    const input = screen.getAllByLabelText("nova tarefa")[0];
+    fireEvent.change(input, { target: { value: "nova card" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onAddTask).toHaveBeenCalledWith("p1", "s1", "nova card");
+    expect(input).toHaveValue("");
+  });
+
+  it("Enter vazio não cria tarefa", () => {
+    const onAddTask = vi.fn();
+    renderKanban({ onAddTask });
+    fireEvent.keyDown(screen.getAllByLabelText("nova tarefa")[0], { key: "Enter" });
+    expect(onAddTask).not.toHaveBeenCalled();
+  });
+
+  it("Esc limpa o rascunho sem criar", () => {
+    const onAddTask = vi.fn();
+    renderKanban({ onAddTask });
+    const input = screen.getAllByLabelText("nova tarefa")[0];
+    fireEvent.change(input, { target: { value: "nova card" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(onAddTask).not.toHaveBeenCalled();
+    expect(input).toHaveValue("");
+  });
+
+  it("usa o projeto escolhido no select ao criar", async () => {
+    const onAddTask = vi.fn();
+    const p2 = projeto({ id: "p2", title: "Q", sections: [{ ...projeto().sections[0], id: "s2" }] });
+    renderKanban({ projetos: [projeto(), p2], onAddTask });
+    await userEvent.click(screen.getAllByLabelText("projeto")[0]);
+    await userEvent.click(await screen.findByRole("option", { name: "Q" }));
+    await userEvent.type(screen.getAllByLabelText("nova tarefa")[0], "na fila{Enter}");
+    expect(onAddTask).toHaveBeenCalledWith("p2", "s2", "na fila");
+  });
+
+  it("coluna vazia mostra o input de criação sempre visível", () => {
+    renderKanban({ projetos: [projeto({ sections: [{ ...projeto().sections[0], tasks: [] }] })] });
+    const row = screen.getAllByLabelText("nova tarefa")[0].parentElement;
+    expect(row?.className).toContain("opacity-100");
   });
 });

--- a/src/components/client/dnd/Kanban.tsx
+++ b/src/components/client/dnd/Kanban.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
 import { sortTasks } from "@/lib/filter";
@@ -6,6 +6,14 @@ import { useT } from "@/hooks/useT";
 import { isDueSoon, isOverdue, fmtDate } from "@/lib/date";
 import { PRIO_CLS, PRIO_KEYS, STATUS_ORDER, type Prio, type Project, type Status } from "@/lib/types";
 import { TaskEditModal } from "@/components/client/board/TaskEditModal";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 interface FlatTask {
   task: Project["sections"][number]["tasks"][number];
@@ -19,6 +27,7 @@ interface KanbanProps {
   projetos: Project[];
   prioSort?: boolean;
   onEditTask: (pid: string, sid: string, tid: string, patch: import("@/lib/types").TaskPatch) => void;
+  onAddTask: (pid: string, sid: string, text: string) => void;
 }
 
 function flatTasks(projetos: Project[]): FlatTask[] {
@@ -110,18 +119,94 @@ function KanbanTask({ item, onEdit }: { item: FlatTask; onEdit: () => void }) {
   );
 }
 
-function DroppableCol({ status, items, onEdit }: { status: Status; items: FlatTask[]; onEdit: (item: FlatTask) => void }) {
+function ColumnAddRow({
+  draft,
+  pid,
+  projetos,
+  empty,
+  onDraftChange,
+  onPidChange,
+  onSubmit,
+}: {
+  draft: string;
+  pid: string | undefined;
+  projetos: Project[];
+  empty: boolean;
+  onDraftChange: (v: string) => void;
+  onPidChange: (v: string | null) => void;
+  onSubmit: () => void;
+}) {
+  const { t } = useT();
+  return (
+    <div
+      className={`flex items-center gap-1 px-2 pb-2 pt-1.5 transition-opacity ${
+        empty ? "opacity-100" : "opacity-0 group-hover:opacity-100 focus-within:opacity-100"
+      }`}
+    >
+      <Select value={pid} onValueChange={onPidChange} disabled={!projetos.length}>
+        <SelectTrigger
+          size="sm"
+          aria-label={t("projeto")}
+          className="h-7 max-w-32 shrink-0 border-[var(--line)] bg-[var(--field)] px-2 text-[11px] text-[var(--muted-text)] hover:border-[var(--muted-text)] hover:text-[var(--text)]"
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {projetos.map((p) => (
+            <SelectItem key={p.id} value={p.id} className="py-1 text-xs">
+              {p.title}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Input
+        value={draft}
+        onChange={(e) => onDraftChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && draft.trim()) {
+            e.preventDefault();
+            onSubmit();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            onDraftChange("");
+          }
+        }}
+        disabled={!projetos.length}
+        className="h-7 min-w-0 flex-1 border-[var(--line)] bg-[var(--field)] px-2 text-xs"
+        placeholder={`${t("nova tarefa")}…`}
+        autoComplete="off"
+        spellCheck={false}
+        aria-label={t("nova tarefa")}
+      />
+    </div>
+  );
+}
+
+function DroppableCol({
+  status,
+  items,
+  onEdit,
+  addRow,
+  empty,
+}: {
+  status: Status;
+  items: FlatTask[];
+  onEdit: (item: FlatTask) => void;
+  addRow: ReactNode;
+  empty: boolean;
+}) {
   const { status: statusLabel } = useT();
   const { setNodeRef, isOver } = useDroppable({ id: `k:${status}` });
   return (
     <div
       ref={setNodeRef}
-      className={`flex min-w-[200px] flex-1 flex-col rounded-lg border ${isOver ? "border-[var(--fired)]/60" : "border-[var(--line)]"} bg-[var(--panel)]`}
+      className={`group flex min-w-[200px] flex-1 flex-col rounded-lg border ${isOver ? "border-[var(--fired)]/60" : "border-[var(--line)]"} bg-[var(--panel)]`}
     >
       <header className="border-b border-[var(--line)] px-3 py-2 text-[11px] font-bold uppercase tracking-wider text-[var(--muted-text)]">
         {statusLabel(status)} <span className="text-[var(--dimmer)]">{items.length}</span>
       </header>
-      <div className="flex min-h-[48px] flex-col gap-1 p-2">
+      {addRow}
+      <div className={`flex flex-col gap-1 px-2 pb-2 ${empty ? "" : "pt-1"}`}>
         {items.map((item) => (
           <KanbanTask key={item.task.id} item={item} onEdit={() => onEdit(item)} />
         ))}
@@ -130,9 +215,11 @@ function DroppableCol({ status, items, onEdit }: { status: Status; items: FlatTa
   );
 }
 
-export function Kanban({ projetos, prioSort, onEditTask }: KanbanProps) {
+export function Kanban({ projetos, prioSort, onEditTask, onAddTask }: KanbanProps) {
   const { t } = useT();
   const [editing, setEditing] = useState<FlatTask | null>(null);
+  const [drafts, setDrafts] = useState<Partial<Record<Status, string>>>({});
+  const [pids, setPids] = useState<Partial<Record<Status, string>>>({});
 
   if (!projetos.length) {
     return (
@@ -143,13 +230,45 @@ export function Kanban({ projetos, prioSort, onEditTask }: KanbanProps) {
     );
   }
 
+  const available = projetos.filter((p) => !p.archived);
+  const colPid = (s: Status): string | undefined =>
+    pids[s] && available.some((p) => p.id === pids[s]) ? pids[s] : available[0]?.id;
+
+  const submit = (s: Status) => {
+    const text = drafts[s]?.trim();
+    const pid = colPid(s);
+    if (!text || !pid) return;
+    const sid = projetos.find((p) => p.id === pid)?.sections[0]?.id;
+    if (!sid) return;
+    onAddTask(pid, sid, text);
+    setDrafts((d) => ({ ...d, [s]: "" }));
+  };
+
   const tasks = sortTasks(flatTasks(projetos), !!prioSort, (i) => i.task.prio);
+  const grouped = STATUS_ORDER.map((s) => ({ status: s, items: tasks.filter((t) => t.task.status === s) }));
 
   return (
     <>
       <div className="fade-in flex flex-wrap gap-3">
-        {STATUS_ORDER.map((s) => (
-          <DroppableCol key={s} status={s} items={tasks.filter((t) => t.task.status === s)} onEdit={setEditing} />
+        {grouped.map(({ status, items }) => (
+          <DroppableCol
+            key={status}
+            status={status}
+            items={items}
+            onEdit={setEditing}
+            empty={items.length === 0}
+            addRow={
+              <ColumnAddRow
+                draft={drafts[status] ?? ""}
+                pid={colPid(status)}
+                projetos={available}
+                empty={items.length === 0}
+                onDraftChange={(v) => setDrafts((d) => ({ ...d, [status]: v }))}
+                onPidChange={(v) => setPids((d) => ({ ...d, [status]: v ?? undefined }))}
+                onSubmit={() => submit(status)}
+              />
+            }
+          />
         ))}
       </div>
       {editing && (


### PR DESCRIPTION
Closes #94

- Input ghost por coluna (placeholder 'nova tarefa…') + mini-select de projeto (base-ui select, default primeiro não-arquivado)
- Enter cria na primeira seção do projeto escolhido; Esc limpa; coluna vazia → input sempre visível
- Board repassa onAddTask (page já passava addTask); sem chaves i18n novas
- 252 unit (+5 Kanban.test); e2e kanban-fluxos +1