### PR TITLE
fix: select de status mostra o label traduzido

### DIFF
--- a/src/components/client/board/TaskRow.test.tsx
+++ b/src/components/client/board/TaskRow.test.tsx
@@ -71,6 +71,11 @@ describe("TaskRow", () => {
     expect(screen.getByText(/vencida/)).toBeTruthy();
   });
 
+  it("trigger do status mostra o label traduzido", () => {
+    render(<TaskRow {...base()} />);
+    expect(screen.getByLabelText("mudar status")).toHaveTextContent("a fazer");
+  });
+
   it("troca status via select", async () => {
     const p = base();
     render(<TaskRow {...p} />);

--- a/src/components/client/board/TaskRow.tsx
+++ b/src/components/client/board/TaskRow.tsx
@@ -159,11 +159,11 @@ export function TaskRow({ task, onToggle, onPrioCycle, onStatusChange, onEdit, o
             title={t("mudar status")}
             className="h-7 border-[var(--line)] bg-[var(--field)] px-2 text-[11px] text-[var(--muted-text)] hover:border-[var(--muted-text)] hover:text-[var(--text)]"
           >
-            <SelectValue />
+            <SelectValue>{status(task.status)}</SelectValue>
           </SelectTrigger>
           <SelectContent>
             {STATUS_ORDER.map((k) => (
-              <SelectItem key={k} value={k} className="py-1 text-xs">
+              <SelectItem key={k} value={k} label={status(k)} className="py-1 text-xs">
                 {status(k)}
               </SelectItem>
             ))}

--- a/src/components/client/dnd/Kanban.tsx
+++ b/src/components/client/dnd/Kanban.tsx
@@ -149,11 +149,11 @@ function ColumnAddRow({
           aria-label={t("projeto")}
           className="h-7 max-w-32 shrink-0 border-[var(--line)] bg-[var(--field)] px-2 text-[11px] text-[var(--muted-text)] hover:border-[var(--muted-text)] hover:text-[var(--text)]"
         >
-          <SelectValue />
+          <SelectValue>{projetos.find((p) => p.id === pid)?.title ?? ""}</SelectValue>
         </SelectTrigger>
         <SelectContent>
           {projetos.map((p) => (
-            <SelectItem key={p.id} value={p.id} className="py-1 text-xs">
+            <SelectItem key={p.id} value={p.id} label={p.title} className="py-1 text-xs">
               {p.title}
             </SelectItem>
           ))}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -111,11 +111,13 @@ function SelectLabel({
 function SelectItem({
   className,
   children,
+  label,
   ...props
 }: SelectPrimitive.Item.Props) {
   return (
     <SelectPrimitive.Item
       data-slot="select-item"
+      label={label}
       className={cn(
         "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className


### PR DESCRIPTION
Closes #100

- Causa: SelectValue do base-ui sem children renderiza o value cru (todo/doing/…) — label do Item é só p/ keyboard nav
- Fix: children no SelectValue (status(task.status)) no TaskRow e (projetos.find(title)) no mini-select de projeto do kanban; label nos SelectItem mantidos p/ a11y
- +1 unit (trigger mostra 'a fazer'); repro browser confirmado: 'a fazer▼'; 20 e2e + unit completos verdes