### PR TITLE
kanban: excluir tarefa (× no hover), prioridade cicla no card e reorder dentro da coluna

### DIFF
--- a/e2e/dnd.spec.ts
+++ b/e2e/dnd.spec.ts
@@ -113,3 +113,22 @@ test("kanban: move tarefa entre colunas (todo → em andamento)", async ({ page 
   await expect(page.getByText("a fazer 0", { exact: true })).toBeVisible();
   await expect(page.getByText("na fila", { exact: true })).toBeVisible();
 });
+test("reordena tarefa dentro da coluna do kanban", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "primeira");
+  await addTask(page, "segunda");
+  await addTask(page, "terceira");
+
+  await page.getByRole("button", { name: "kanban" }).click();
+  const cards = page.getByTestId("kanban-task");
+  await expect(cards).toHaveCount(3);
+  await expect(cards.nth(0)).toContainText("primeira");
+  await expect(cards.nth(2)).toContainText("terceira");
+
+  await drag(page, cards.nth(0), cards.nth(1));
+
+  await expect(cards.nth(0)).toContainText("segunda");
+  await expect(cards.nth(1)).toContainText("primeira");
+  await expect(cards.nth(2)).toContainText("terceira");
+});

--- a/e2e/kanban-fluxos.spec.ts
+++ b/e2e/kanban-fluxos.spec.ts
@@ -192,3 +192,28 @@ test("kanban: modal de criação permite escolher o projeto", async ({ page }) =
   const card = page.getByTestId("kanban-task").filter({ hasText: "no web" });
   await expect(card).toContainText("web · geral");
 });
+
+test("kanban: × no hover exclui o card", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "descartável");
+
+  await page.getByRole("button", { name: "kanban" }).click();
+  const card = page.getByTestId("kanban-task").filter({ hasText: "descartável" });
+  await card.getByRole("button", { name: "excluir" }).click();
+  await expect(card).toHaveCount(0);
+  await expect(page.getByText("descartável")).toHaveCount(0);
+});
+
+test("kanban: prio cicla no badge do card", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "ciclar");
+
+  await page.getByRole("button", { name: "kanban" }).click();
+  const card = page.getByTestId("kanban-task").filter({ hasText: "ciclar" });
+  await expect(card.getByText("P3", { exact: true })).toBeVisible();
+  await card.getByRole("button", { name: "prioridade: clique pra mudar" }).click();
+  await expect(card.getByText("P1", { exact: true })).toBeVisible();
+  await expect(page.getByRole("dialog", { name: "editar tarefa" })).toHaveCount(0);
+});

--- a/src/components/client/board/Board.tsx
+++ b/src/components/client/board/Board.tsx
@@ -1,8 +1,8 @@
-import { DndContext, PointerSensor, TouchSensor, rectIntersection, useSensor, useSensors, type DragEndEvent } from "@dnd-kit/core";
+import { DndContext, PointerSensor, TouchSensor, useSensor, useSensors, type DragEndEvent } from "@dnd-kit/core";
 import { useMemo } from "react";
 import { useT } from "@/hooks/useT";
 import { isFiltering, prioSort, projMatches, type Filters } from "@/lib/filter";
-import { resolveDrop } from "@/lib/dnd";
+import { resolveDrop, smartCollision } from "@/lib/dnd";
 import type { AddTaskInput, Project, Status, TaskPatch } from "@/lib/types";
 import { ProjectCard } from "./ProjectCard";
 import { Kanban } from "@/components/client/dnd/Kanban";
@@ -137,6 +137,7 @@ export function Board({ projetos, filters, onNewProject, onClearFilters, project
         projetos={filtered}
         prioSort={filters.prioSort}
         onEditTask={(pid, sid, tid, patch) => taskActions.onEdit(pid, sid, tid, patch)}
+        onDeleteTask={(pid, sid, tid) => taskActions.onDelete(pid, sid, tid)}
         onAddTask={(pid, sid, input) => sectionActions.onAddTaskFull(pid, sid, input)}
       />
     );
@@ -163,7 +164,7 @@ export function Board({ projetos, filters, onNewProject, onClearFilters, project
   }
 
   return (
-    <DndContext sensors={sensors} collisionDetection={rectIntersection} onDragEnd={handleDragEnd}>
+    <DndContext sensors={sensors} collisionDetection={smartCollision} onDragEnd={handleDragEnd}>
       {content}
     </DndContext>
   );

--- a/src/components/client/dnd/Kanban.test.tsx
+++ b/src/components/client/dnd/Kanban.test.tsx
@@ -25,11 +25,17 @@ const projeto = (over: Partial<Project> = {}): Project => ({
   ...over,
 });
 
-const renderKanban = (props: { projetos?: Project[]; onEditTask?: (pid: string, sid: string, tid: string, patch: TaskPatch) => void; onAddTask?: (pid: string, sid: string, input: AddTaskInput) => void } = {}) =>
+const renderKanban = (props: {
+  projetos?: Project[];
+  onEditTask?: (pid: string, sid: string, tid: string, patch: TaskPatch) => void;
+  onDeleteTask?: (pid: string, sid: string, tid: string) => void;
+  onAddTask?: (pid: string, sid: string, input: AddTaskInput) => void;
+} = {}) =>
   render(
     <Kanban
       projetos={props.projetos ?? [projeto()]}
       onEditTask={props.onEditTask ?? (() => {})}
+      onDeleteTask={props.onDeleteTask ?? (() => {})}
       onAddTask={props.onAddTask ?? (() => {})}
     />,
   );
@@ -187,5 +193,35 @@ it("title do card é o texto da tarefa", () => {
       "s2",
       expect.objectContaining({ text: "na fila", status: "todo" }),
     );
+  });
+
+  it("× no card chama onDeleteTask sem abrir o modal", () => {
+    const onDeleteTask = vi.fn();
+    renderKanban({ onDeleteTask });
+    const card = screen.getByRole("button", { name: /editar tarefa correr pra base/ });
+    fireEvent.click(within(card).getByRole("button", { name: "excluir" }));
+    expect(onDeleteTask).toHaveBeenCalledWith("p1", "s1", "t1");
+    expect(screen.queryByText("editar tarefa")).toBeNull();
+  });
+
+  it("clique no badge de prioridade cicla prio via onEditTask sem abrir modal", () => {
+    const onEditTask = vi.fn();
+    renderKanban({
+      onEditTask,
+      projetos: [projeto({ sections: [{ ...projeto().sections[0], tasks: [
+        { ...projeto().sections[0].tasks[0], prio: 1 },
+      ] }] })],
+    });
+    const card = screen.getByRole("button", { name: /editar tarefa correr pra base/ });
+    fireEvent.click(within(card).getByRole("button", { name: "prioridade: clique pra mudar" }));
+    expect(onEditTask).toHaveBeenCalledWith("p1", "s1", "t1", { prio: 2 });
+    expect(screen.queryByText("editar tarefa")).toBeNull();
+  });
+
+  it("teclado no botão excluir não abre o modal", () => {
+    renderKanban({});
+    const card = screen.getByRole("button", { name: /editar tarefa correr pra base/ });
+    fireEvent.keyDown(within(card).getByRole("button", { name: "excluir" }), { key: "Enter" });
+    expect(screen.queryByText("editar tarefa")).toBeNull();
   });
 });

--- a/src/components/client/dnd/Kanban.tsx
+++ b/src/components/client/dnd/Kanban.tsx
@@ -6,6 +6,7 @@ import { useT } from "@/hooks/useT";
 import { isDueSoon, isOverdue, fmtDate } from "@/lib/date";
 import { PRIO_CLS, PRIO_KEYS, STATUS_ORDER, type AddTaskInput, type Project, type Status, type Task, type TaskPatch } from "@/lib/types";
 import { TaskEditModal } from "@/components/client/board/TaskEditModal";
+import { NEXT_PRIO } from "@/components/client/board/TaskRow";
 
 interface FlatTask {
   task: Project["sections"][number]["tasks"][number];
@@ -19,6 +20,7 @@ interface KanbanProps {
   projetos: Project[];
   prioSort?: boolean;
   onEditTask: (pid: string, sid: string, tid: string, patch: TaskPatch) => void;
+  onDeleteTask: (pid: string, sid: string, tid: string) => void;
   onAddTask: (pid: string, sid: string, input: AddTaskInput) => void;
 }
 
@@ -28,15 +30,31 @@ function flatTasks(projetos: Project[]): FlatTask[] {
   );
 }
 
-function KanbanTask({ item, onEdit }: { item: FlatTask; onEdit: () => void }) {
+function KanbanTask({
+  item,
+  onEdit,
+  onUpdate,
+  onDelete,
+}: {
+  item: FlatTask;
+  onEdit: () => void;
+  onUpdate: (patch: TaskPatch) => void;
+  onDelete: () => void;
+}) {
   const { t } = useT();
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id: `task:${item.task.id}` });
+  const { setNodeRef: setCardDropRef } = useDroppable({ id: `task:${item.task.id}` });
+  const setRefs = (el: HTMLDivElement | null) => {
+    setNodeRef(el);
+    setCardDropRef(el);
+  };
   const start = useRef<{ x: number; y: number } | null>(null);
   const overdue = isOverdue(item.task.due, item.task.status);
   const dueSoon = isDueSoon(item.task.due, item.task.status);
+  const onInteractive = (e: { target: EventTarget }) => (e.target as HTMLElement).closest("button") != null;
   return (
     <div
-      ref={setNodeRef}
+      ref={setRefs}
       style={{ transform: CSS.Translate.toString(transform) }}
       className={`cursor-grab rounded-md border border-[var(--line)] bg-[var(--panel-2)] px-2.5 py-1.5 text-xs hover:bg-[var(--panel-3)] ${isDragging ? "opacity-90 shadow-lg ring-2 ring-[var(--fired)]/70 z-10" : ""}`}
       data-testid="kanban-task"
@@ -46,6 +64,7 @@ function KanbanTask({ item, onEdit }: { item: FlatTask; onEdit: () => void }) {
         start.current = { x: e.clientX, y: e.clientY };
       }}
       onClick={(e) => {
+        if (onInteractive(e)) return;
         const s = start.current;
         start.current = null;
         if (!s) {
@@ -56,6 +75,7 @@ function KanbanTask({ item, onEdit }: { item: FlatTask; onEdit: () => void }) {
         if (!moved) onEdit();
       }}
       onKeyDown={(e) => {
+        if (onInteractive(e)) return;
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
           onEdit();
@@ -74,9 +94,18 @@ function KanbanTask({ item, onEdit }: { item: FlatTask; onEdit: () => void }) {
             {item.ptitle} · {item.stitle}
           </span>
         </span>
-        <span className={`shrink-0 rounded border px-1 py-0.5 text-[9px] font-bold ${PRIO_CLS[item.task.prio]}`}>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onUpdate({ prio: NEXT_PRIO[item.task.prio] });
+          }}
+          aria-label={t("prioridade: clique pra mudar")}
+          title={t("prioridade: clique pra mudar")}
+          className={`shrink-0 rounded border px-1 py-0.5 text-[9px] font-bold ${PRIO_CLS[item.task.prio]}`}
+        >
           {PRIO_KEYS[item.task.prio]}
-        </span>
+        </button>
         {item.task.subs.length > 0 && (
           <span
             className="shrink-0 rounded border border-[var(--line-soft)] px-1 py-0.5 text-[9px] text-[var(--dim)]"
@@ -86,6 +115,18 @@ function KanbanTask({ item, onEdit }: { item: FlatTask; onEdit: () => void }) {
             {item.task.subs.filter((s) => s.status === "done").length}/{item.task.subs.length}
           </span>
         )}
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          title="excluir"
+          aria-label="excluir"
+          className="shrink-0 rounded px-1 text-xs leading-none text-[var(--dimmer)] opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 hover:text-[var(--fired)]"
+        >
+          ×
+        </button>
       </div>
       <div className="mt-1 flex items-center gap-1.5">
         {item.task.blocked && (
@@ -115,12 +156,16 @@ function DroppableCol({
   status,
   items,
   onEdit,
+  onUpdate,
+  onDelete,
   onCreate,
   empty,
 }: {
   status: Status;
   items: FlatTask[];
   onEdit: (item: FlatTask) => void;
+  onUpdate: (item: FlatTask, patch: TaskPatch) => void;
+  onDelete: (item: FlatTask) => void;
   onCreate: () => void;
   empty: boolean;
 }) {
@@ -147,7 +192,13 @@ function DroppableCol({
       </header>
       <div className={`flex flex-col gap-1 px-2 pb-2 ${empty ? "" : "pt-1"}`}>
         {items.map((item) => (
-          <KanbanTask key={item.task.id} item={item} onEdit={() => onEdit(item)} />
+          <KanbanTask
+            key={item.task.id}
+            item={item}
+            onEdit={() => onEdit(item)}
+            onUpdate={(patch) => onUpdate(item, patch)}
+            onDelete={() => onDelete(item)}
+          />
         ))}
       </div>
     </div>
@@ -166,7 +217,7 @@ const emptyTask: Task = {
   subs: [],
 };
 
-export function Kanban({ projetos, prioSort, onEditTask, onAddTask }: KanbanProps) {
+export function Kanban({ projetos, prioSort, onEditTask, onDeleteTask, onAddTask }: KanbanProps) {
   const { t } = useT();
   const [editing, setEditing] = useState<FlatTask | null>(null);
   const [creating, setCreating] = useState<Status | null>(null);
@@ -193,6 +244,8 @@ export function Kanban({ projetos, prioSort, onEditTask, onAddTask }: KanbanProp
             status={status}
             items={items}
             onEdit={setEditing}
+            onUpdate={(item, patch) => onEditTask(item.pid, item.sid, item.task.id, patch)}
+            onDelete={(item) => onDeleteTask(item.pid, item.sid, item.task.id)}
             onCreate={() => {
               if (available.length) setCreating(status);
             }}

--- a/src/lib/dnd.test.ts
+++ b/src/lib/dnd.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyStatusDrop, insertIndex, resolveDrop } from "./dnd";
+import { applyStatusDrop, insertIndex, resolveDrop, smartCollision } from "./dnd";
 import type { Project } from "./types";
 
 const projeto = (over: Partial<Project> = {}): Project => ({
@@ -119,6 +119,43 @@ describe("insertIndex", () => {
   it("retorna o índice do alvo (remoção já aplicada)", () => {
     expect(insertIndex({ overIdx: 3 })).toBe(3);
     expect(insertIndex({ overIdx: 0 })).toBe(0);
+  });
+});
+
+describe("smartCollision", () => {
+  const rect = (left: number, top: number, width: number, height: number) => ({ left, top, right: left + width, bottom: top + height, width, height });
+
+  it("prioriza o menor rect que contém o pointer (card vence a coluna)", () => {
+    const cols = new Map<string, ReturnType<typeof rect>>();
+    const coluna = rect(0, 0, 300, 500);
+    const card = rect(10, 10, 280, 60);
+    cols.set("k:todo", coluna);
+    cols.set("task:t2", card);
+    const pointerCoordinates = { x: 50, y: 30 };
+    const collisions = smartCollision({
+      droppableRects: cols,
+      droppableContainers: [{ id: "k:todo" }, { id: "task:t2" }] as never,
+      collisionRect: card,
+      pointerCoordinates,
+      active: { id: "task:t1", data: { current: undefined } } as never,
+    });
+    expect(collisions[0].id).toBe("task:t2");
+  });
+
+  it("sem pointer no rect, mantém o comportamento do rectIntersection", () => {
+    const cols = new Map<string, ReturnType<typeof rect>>();
+    const coluna = rect(0, 0, 300, 500);
+    const card = rect(10, 10, 280, 60);
+    cols.set("k:todo", coluna);
+    cols.set("task:t2", card);
+    const collisions = smartCollision({
+      droppableRects: cols,
+      droppableContainers: [{ id: "k:todo" }, { id: "task:t2" }] as never,
+      collisionRect: rect(0, 0, 300, 500),
+      pointerCoordinates: { x: 10, y: 400 },
+      active: { id: "task:t1", data: { current: undefined } } as never,
+    });
+    expect(collisions[0].id).toBe("k:todo");
   });
 });
 

--- a/src/lib/dnd.ts
+++ b/src/lib/dnd.ts
@@ -1,4 +1,29 @@
 import type { Project, Status } from "@/lib/types";
+import { rectIntersection, type CollisionDetection, type Collision } from "@dnd-kit/core";
+
+function containsPoint(rect: { left: number; top: number; right: number; bottom: number }, x: number, y: number): boolean {
+  return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+}
+
+export const smartCollision: CollisionDetection = (args) => {
+  const base = rectIntersection(args);
+  const { pointerCoordinates, droppableRects } = args;
+  if (!pointerCoordinates) return base;
+  const containing = base
+    .map((c): Collision & { area: number } => {
+      const rect = droppableRects.get(c.id);
+      return { ...c, area: rect ? rect.width * rect.height : Infinity };
+    })
+    .filter((c) => {
+      const rect = droppableRects.get(c.id);
+      return rect != null && containsPoint(rect, pointerCoordinates.x, pointerCoordinates.y);
+    })
+    .sort((a, b) => a.area - b.area);
+  if (containing.length > 0) {
+    return containing.map((c) => ({ id: c.id, data: c.data }));
+  }
+  return base;
+};
 
 export interface OverInfo {
   overIdx: number;


### PR DESCRIPTION
Closes #106

## Escopo (aprovado pelo usuário)
- **Excluir tarefa**: botão × no hover do card (não no modal), com stopPropagation e guard de teclado
- **Prioridade cicla**: clique no badge P1/P2/P3 do card cicla via NEXT_PRIO (igual lista)
- **Reorder dentro da coluna**: arrasto do card sobre outro card reordena (arrayMove)

## Como
- `KanbanTask` vira droppable+draggable (task:{id}) — o drag entre colunas funciona porque o card é droppable e o **novo `smartCollision`** (lib/dnd.ts) prioriza o menor rect que contém o pointer (card vence a coluna; senão mantém rectIntersection)
- `useSortable` abandonado no kanban: com sortable o dnd-kit congela o collision (transform null, over null) fora do contêiner — draggable puro + droppable por card resolve
- Reorder: `resolveDrop("task:")` existente → `moveTask` (1 commit de undo)
- Guard de 6px (click vs drag) + `onInteractive` (closest button) preservados

## Testes
- Unit: +2 `smartCollision` (card vence coluna; fallback), total **286**
- e2e: +3 (× exclui card; prio cicla no badge; reorder na coluna), total **77** — incluindo regressão de drag entre colunas e reorder da lista
