### PR TITLE
kanban: contador de sub-tarefas abre o modal focado na seção de subs

### DIFF
--- a/e2e/kanban-fluxos.spec.ts
+++ b/e2e/kanban-fluxos.spec.ts
@@ -217,3 +217,25 @@ test("kanban: prio cicla no badge do card", async ({ page }) => {
   await expect(card.getByText("P1", { exact: true })).toBeVisible();
   await expect(page.getByRole("dialog", { name: "editar tarefa" })).toHaveCount(0);
 });
+
+test("kanban: contador de subs abre o modal focado na seção de sub-tarefas", async ({ page }) => {
+  await page.goto("/");
+  await createProject(page, "app");
+  await addTask(page, "com sub");
+
+  const row = page.getByTestId("task-row").filter({ hasText: "com sub" });
+  await row.getByRole("button", { name: "editar", exact: true }).click();
+  await page.getByRole("textbox", { name: "nova sub-tarefa" }).fill("x");
+  await page.getByRole("textbox", { name: "nova sub-tarefa" }).press("Enter");
+  await page.getByRole("button", { name: "salvar" }).click();
+
+  await page.getByRole("button", { name: "kanban" }).click();
+  const card = page.getByTestId("kanban-task").filter({ hasText: "com sub" });
+  await card.getByRole("button", { name: "sub-tarefas 0/1" }).click();
+  const dialog = page.getByRole("dialog", { name: "editar tarefa" });
+  await expect(dialog).toBeVisible();
+  await expect(page.getByTestId("subs-section")).toBeInViewport();
+  await page.getByRole("checkbox", { name: "sub-tarefa x" }).click();
+  await page.getByRole("button", { name: "salvar" }).click();
+  await expect(card.getByRole("button", { name: "sub-tarefas 1/1" })).toBeVisible();
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -120,6 +120,9 @@ body {
 .fade-in {
   animation: fade 180ms cubic-bezier(0.23, 1, 0.32, 1);
 }
+[data-focus] {
+  box-shadow: 0 0 0 2px var(--fired);
+}
 @keyframes fade {
   from {
     opacity: 0;

--- a/src/components/client/board/TaskEditModal.tsx
+++ b/src/components/client/board/TaskEditModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Modal } from "@/components/client/Modal";
 import { Label } from "@/components/ui/label";
 import { useT } from "@/hooks/useT";
@@ -17,16 +17,31 @@ export interface TaskEditModalProps {
   isSub?: boolean;
   status?: Status;
   projetos?: Project[];
+  focusSubs?: boolean;
   onSubmit: (patch: TaskPatch, pid?: string) => void;
   onCancel: () => void;
 }
 
-export function TaskEditModal({ task, isSub, status, projetos, onSubmit, onCancel }: TaskEditModalProps) {
+export function TaskEditModal({ task, isSub, status, projetos, focusSubs, onSubmit, onCancel }: TaskEditModalProps) {
   const { t, status: statusLabel } = useT();
   const isCreate = status !== undefined;
   const [subs, setSubs] = useState<SubTask[]>(task?.subs ?? []);
   const [newSub, setNewSub] = useState("");
   const [pid, setPid] = useState<string | null>(projetos?.[0]?.id ?? null);
+  const subsRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!focusSubs) return;
+    const el = subsRef.current;
+    const scrollId = window.setTimeout(() => {
+      subsRef.current?.scrollIntoView?.({ block: "center", behavior: "smooth" });
+    }, 50);
+    const clearId = window.setTimeout(() => el?.removeAttribute("data-focus"), 1600);
+    return () => {
+      window.clearTimeout(scrollId);
+      window.clearTimeout(clearId);
+    };
+  }, [focusSubs]);
 
   const addSub = () => {
     const text = newSub.trim();
@@ -109,7 +124,12 @@ export function TaskEditModal({ task, isSub, status, projetos, onSubmit, onCance
       onSubmit={submit}
       onCancel={onCancel}
     >
-      <div className="rounded-md border border-[var(--line)] bg-[var(--panel)] p-2.5">
+      <div
+        ref={subsRef}
+        data-testid="subs-section"
+        data-focus={focusSubs ? "" : undefined}
+        className="rounded-md border border-[var(--line)] bg-[var(--panel)] p-2.5"
+      >
         <Label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-wider text-[var(--muted-text)]">
           sub-tarefas
         </Label>

--- a/src/components/client/dnd/Kanban.test.tsx
+++ b/src/components/client/dnd/Kanban.test.tsx
@@ -132,6 +132,22 @@ it("clique no card abre o modal de edição e submit chama onEditTask", () => {
     expect(screen.getByLabelText("sub-tarefas 1/2")).toBeTruthy();
   });
 
+  it("contador de subs abre o modal com foco na seção de sub-tarefas", () => {
+    const onEditTask = vi.fn();
+    renderKanban({
+      onEditTask,
+      projetos: [projeto({ sections: [{ ...projeto().sections[0], tasks: [
+        { ...projeto().sections[0].tasks[0], subs: [
+          { id: "s1", text: "a", note: "", prio: 3, due: "", status: "done", blocked: false, subs: [] },
+        ] },
+      ] }] })],
+    });
+    fireEvent.click(screen.getByRole("button", { name: "sub-tarefas 1/1" }));
+    expect(screen.getByRole("dialog", { name: "editar tarefa" })).toBeTruthy();
+    expect(screen.getByTestId("subs-section")).toHaveAttribute("data-focus", "");
+    expect(onEditTask).not.toHaveBeenCalled();
+  });
+
   it("adiciona e alterna sub-tarefa no modal e salva com subs", () => {
     const onEditTask = vi.fn();
     renderKanban({ onEditTask });

--- a/src/components/client/dnd/Kanban.tsx
+++ b/src/components/client/dnd/Kanban.tsx
@@ -35,11 +35,13 @@ function KanbanTask({
   onEdit,
   onUpdate,
   onDelete,
+  onSubs,
 }: {
   item: FlatTask;
   onEdit: () => void;
   onUpdate: (patch: TaskPatch) => void;
   onDelete: () => void;
+  onSubs: () => void;
 }) {
   const { t } = useT();
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id: `task:${item.task.id}` });
@@ -107,13 +109,18 @@ function KanbanTask({
           {PRIO_KEYS[item.task.prio]}
         </button>
         {item.task.subs.length > 0 && (
-          <span
-            className="shrink-0 rounded border border-[var(--line-soft)] px-1 py-0.5 text-[9px] text-[var(--dim)]"
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onSubs();
+            }}
             title={`${item.task.subs.filter((s) => s.status === "done").length}/${item.task.subs.length} sub-tarefas concluídas`}
             aria-label={`sub-tarefas ${item.task.subs.filter((s) => s.status === "done").length}/${item.task.subs.length}`}
+            className="shrink-0 rounded border border-[var(--line-soft)] px-1 py-0.5 text-[9px] text-[var(--dim)] transition-colors hover:border-[var(--muted-text)] hover:text-[var(--text)]"
           >
             {item.task.subs.filter((s) => s.status === "done").length}/{item.task.subs.length}
-          </span>
+          </button>
         )}
         <button
           type="button"
@@ -158,6 +165,7 @@ function DroppableCol({
   onEdit,
   onUpdate,
   onDelete,
+  onSubs,
   onCreate,
   empty,
 }: {
@@ -166,6 +174,7 @@ function DroppableCol({
   onEdit: (item: FlatTask) => void;
   onUpdate: (item: FlatTask, patch: TaskPatch) => void;
   onDelete: (item: FlatTask) => void;
+  onSubs: (item: FlatTask) => void;
   onCreate: () => void;
   empty: boolean;
 }) {
@@ -198,6 +207,7 @@ function DroppableCol({
             onEdit={() => onEdit(item)}
             onUpdate={(patch) => onUpdate(item, patch)}
             onDelete={() => onDelete(item)}
+            onSubs={() => onSubs(item)}
           />
         ))}
       </div>
@@ -221,6 +231,7 @@ export function Kanban({ projetos, prioSort, onEditTask, onDeleteTask, onAddTask
   const { t } = useT();
   const [editing, setEditing] = useState<FlatTask | null>(null);
   const [creating, setCreating] = useState<Status | null>(null);
+  const [focusSubs, setFocusSubs] = useState(false);
 
   if (!projetos.length) {
     return (
@@ -244,6 +255,10 @@ export function Kanban({ projetos, prioSort, onEditTask, onDeleteTask, onAddTask
             status={status}
             items={items}
             onEdit={setEditing}
+            onSubs={(item) => {
+              setEditing(item);
+              setFocusSubs(true);
+            }}
             onUpdate={(item, patch) => onEditTask(item.pid, item.sid, item.task.id, patch)}
             onDelete={(item) => onDeleteTask(item.pid, item.sid, item.task.id)}
             onCreate={() => {
@@ -256,11 +271,16 @@ export function Kanban({ projetos, prioSort, onEditTask, onDeleteTask, onAddTask
       {editing && (
         <TaskEditModal
           task={editing.task}
+          focusSubs={focusSubs}
           onSubmit={(patch) => {
             onEditTask(editing.pid, editing.sid, editing.task.id, patch);
             setEditing(null);
+            setFocusSubs(false);
           }}
-          onCancel={() => setEditing(null)}
+          onCancel={() => {
+            setEditing(null);
+            setFocusSubs(false);
+          }}
         />
       )}
       {creating && (


### PR DESCRIPTION
Closes #110

## Escopo (aprovado)
Sub-tarefas **só no modal** (evitar poluição do card): o contador `2/3` do card kanban vira botão clicável que abre o `TaskEditModal` com a seção de sub-tarefas focada.

## Como
- `Kanban.tsx`: contador span → `<button>` (`stopPropagation`, guard de drag preservado); novo `onSubs` abre o modal com `focusSubs`
- `TaskEditModal.tsx`: prop opcional `focusSubs` → `data-focus` na seção de subs (destaque via `box-shadow` em `globals.css`) + `scrollIntoView` após 50ms (portal do DialogContent monta o conteúdo depois do effect — ref null no primeiro commit); sem setState no effect (regra react-compiler)
- Lista: sem mudança

## Testes
- Unit: **287** (novo: contador abre modal com `data-focus`, sem chamar `onEditTask`)
- e2e: **78** (novo: cria sub na lista → kanban → clica `0/1` → seção no viewport → marca sub → `1/1`)

## Detalhe dnd/base-ui
- Clique no contador não inicia drag nem abre o modal do card (guard `onInteractive` + `stopPropagation`)
- `data-focus` removido do DOM após 1,6s via timeout no effect (sem cascading render)
