### PR TITLE
Perf: memoizar flatTasks/sortTasks no Kanban e Trash

### DIFF
--- a/src/components/client/dnd/Kanban.tsx
+++ b/src/components/client/dnd/Kanban.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
 import { sortTasks } from "@/lib/filter";
@@ -224,6 +224,14 @@ export function Kanban({ projetos, prioSort, onEditTask, onDeleteTask, onAddTask
   const [editing, setEditing] = useState<FlatTask | null>(null);
   const [creating, setCreating] = useState<Status | null>(null);
   const [focusSubs, setFocusSubs] = useState(false);
+  const grouped = useMemo(
+    () =>
+      STATUS_ORDER.map((s) => ({
+        status: s,
+        items: sortTasks(flatTasks(projetos), !!prioSort, (i) => i.task.prio).filter((t) => t.task.status === s),
+      })),
+    [projetos, prioSort],
+  );
 
   if (!projetos.length) {
     return (
@@ -235,8 +243,6 @@ export function Kanban({ projetos, prioSort, onEditTask, onDeleteTask, onAddTask
   }
 
   const available = projetos.filter((p) => !p.archived);
-  const tasks = sortTasks(flatTasks(projetos), !!prioSort, (i) => i.task.prio);
-  const grouped = STATUS_ORDER.map((s) => ({ status: s, items: tasks.filter((t) => t.task.status === s) }));
 
   return (
     <>

--- a/src/components/client/trash/Trash.tsx
+++ b/src/components/client/trash/Trash.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useT } from "@/hooks/useT";
 import { flatTasks } from "@/lib/flat";
 import type { Project } from "@/lib/types";
@@ -10,8 +11,12 @@ interface TrashProps {
 
 export function Trash({ projetos, onRestore, onPurge }: TrashProps) {
   const { t } = useT();
-  const items = flatTasks(projetos, true).toSorted((a, b) =>
-    (b.task.deletedAt ?? "").localeCompare(a.task.deletedAt ?? ""),
+  const items = useMemo(
+    () =>
+      flatTasks(projetos, true).toSorted((a, b) =>
+        (b.task.deletedAt ?? "").localeCompare(a.task.deletedAt ?? ""),
+      ),
+    [projetos],
   );
 
   if (!items.length) {


### PR DESCRIPTION
Closes #124

Micro-otimização de render (regra vercel `js-index-maps`):

- **Kanban**: `flatTasks(projetos)` + `sortTasks` + agrupamento por status agora em `useMemo` (deps `[projetos, prioSort]`) — antes recomputado a cada render
- **Trash**: `flatTasks(projetos, true)` + `.toSorted()` em `useMemo` (deps `[projetos]`)

Sem mudança de comportamento. **313 unit + 17 e2e** (kanban-fluxos, trash-ttl, schema-v7) verdes.
